### PR TITLE
Added support for detecting ADLS Gen2 usage on an SA

### DIFF
--- a/CLOUD/Get-AzureVMSQLInfo.ps1
+++ b/CLOUD/Get-AzureVMSQLInfo.ps1
@@ -639,6 +639,7 @@ foreach ($sub in $subs) {
       $azSAObj = [ordered] @{}
       $azSAObj.Add("StorageAccount",$azSA.StorageAccountName)
       $azSAObj.Add("StorageAccountType",$azSA.Kind)
+      $azSAObj.Add("HNSEnabled",$azSA.EnableHierarchicalNamespace)
       $azSAObj.Add("StorageAccountSkuName",$azSA.Sku.Name)
       $azSAObj.Add("StorageAccountAccessTier",$azSA.AccessTier)
       $azSAObj.Add("Tenant",$tenant.Name)
@@ -706,6 +707,7 @@ foreach ($sub in $subs) {
           $azConObj.Add("Name",$azCon.Name)
           $azConObj.Add("StorageAccount",$azSA.StorageAccountName)
           $azConObj.Add("StorageAccountType",$azSA.Kind)
+          $azConObj.Add("HNSEnabled",$azSA.EnableHierarchicalNamespace)
           $azConObj.Add("StorageAccountSkuName",$azSA.Sku.Name)
           $azConObj.Add("StorageAccountAccessTier",$azSA.AccessTier)
           $azConObj.Add("Tenant",$tenant.Name)

--- a/CLOUD/Get-AzureVMSQLInfo.ps1
+++ b/CLOUD/Get-AzureVMSQLInfo.ps1
@@ -639,7 +639,7 @@ foreach ($sub in $subs) {
       $azSAObj = [ordered] @{}
       $azSAObj.Add("StorageAccount",$azSA.StorageAccountName)
       $azSAObj.Add("StorageAccountType",$azSA.Kind)
-      $azSAObj.Add("HNSEnabled",$azSA.EnableHierarchicalNamespace)
+      $azSAObj.Add("HNSEnabled(ADLSGen2)",$azSA.EnableHierarchicalNamespace)
       $azSAObj.Add("StorageAccountSkuName",$azSA.Sku.Name)
       $azSAObj.Add("StorageAccountAccessTier",$azSA.AccessTier)
       $azSAObj.Add("Tenant",$tenant.Name)
@@ -707,7 +707,7 @@ foreach ($sub in $subs) {
           $azConObj.Add("Name",$azCon.Name)
           $azConObj.Add("StorageAccount",$azSA.StorageAccountName)
           $azConObj.Add("StorageAccountType",$azSA.Kind)
-          $azConObj.Add("HNSEnabled",$azSA.EnableHierarchicalNamespace)
+          $azConObj.Add("HNSEnabled(ADLSGen2)",$azSA.EnableHierarchicalNamespace)
           $azConObj.Add("StorageAccountSkuName",$azSA.Sku.Name)
           $azConObj.Add("StorageAccountAccessTier",$azSA.AccessTier)
           $azConObj.Add("Tenant",$tenant.Name)


### PR DESCRIPTION
Added a check for the `EnableHierarchicalNamespace` expanded property on each Storage Account that is queried.  This will indicate whether ADLS Gen2 is enabled on StorageV2 and BlockBlobStorage type Storage Accounts.