### PR TITLE
Fixed default behavior when no options are selected

### DIFF
--- a/CLOUD/Get-AWSEC2RDSInfo.ps1
+++ b/CLOUD/Get-AWSEC2RDSInfo.ps1
@@ -204,9 +204,8 @@
     PS /home/cloudshell-user> ./Get-AWSEC2RDSInfo.ps1 -SSORoleName AdministratorAccess -SSOStartURL "https://mycompany.awsapps.com/start#/"
 
 #>
-
+[CmdletBinding(DefaultParameterSetName = 'DefaultProfile')]
 param (
-  [CmdletBinding(DefaultParameterSetName = 'DefaultProfile')]
 
   # Choose to get info for all detected AWS accounts in locally defined profiles.
   [Parameter(ParameterSetName='AllLocalProfiles',
@@ -225,7 +224,7 @@ param (
   [string]$CrossAccountRoleName,
   # Choose to get info for only the default profile account (default option).
   [Parameter(ParameterSetName='DefaultProfile',
-    Mandatory=$true)]
+    Mandatory=$false)]
   [ValidateNotNullOrEmpty()]
   [switch]$DefaultProfile,
   # Get Info from AWS SSO

--- a/CLOUD/Get-AWSEC2RDSInfo.ps1
+++ b/CLOUD/Get-AWSEC2RDSInfo.ps1
@@ -268,7 +268,10 @@ param (
 )
 
 # Print Powershell Version
-Write-Debug $PSVersionTable | Format-List
+Write-Debug "$($PSVersionTable | Out-String)"
+
+# Print Powershell CMDLet Parameter Set
+Write-Debug "$($PSCmdlet | Out-String)"
 
 # Set default regions for queries
 $defaultQueryRegion = "us-east-1"


### PR DESCRIPTION
When no options were presented, the script would default to searching an AWS Org. This is incorrect, the script should search the account specified by the user's default profile. This issue has been fixed. 

Also added additional debugging output.

Also added more error handling for the AWS SSO feature. 