### PR TITLE
colsep updates in sql scripts

### DIFF
--- a/ORACLE/README.txt
+++ b/ORACLE/README.txt
@@ -2,7 +2,7 @@
 #
 # Rubrik Data Collection for Oracle Tooling
 # 
-# Version: 1.1
+# Version: 1.2
 #
 # Developer: Shawn McElhinney
 #

--- a/ORACLE/rbkDataCollection.sql
+++ b/ORACLE/rbkDataCollection.sql
@@ -368,7 +368,7 @@ commit;
 -- format data collected for csv output
 -- set markup csv on
 set linesize 32000
-set colsep ,
+set colsep ,,
 set headsep off
 set head off
 set trimspool on
@@ -381,45 +381,46 @@ spool rbkDiscovery.csv append
 
 -- select * from rubrikDataCollection;
 -- 20230322 - reordering query output to logically group data - smcelhinney
-select con_id ||','||
-        conName ||','||
-        dbSizeMB ||','||
-        allocated_dbSizeMB ||','||
-        dailyChangeRate ||','||
-        dailyRedoSize ||','||
-        datafileCount ||','||
-        tablespaceCount ||','||
-        encryptedTablespaceCount ||','||
-        encryptedDataSizeMB ||','||
-        biggestBigfileMB ||','||
-        bigfileTablespaceCount ||','||
-        bigfileDataSizeMB ||','||
-        blockSize ||','||
-        hostName ||','||
-        instName ||','||
-        dbVersion ||','||
-        dbEdition ||','||
-        platformName ||','||
-        dbName ||','||
-        dbUniqueName ||','||
-        dbID ||','||
-        flashbackEnabled ||','||
-        archiveLogEnabled ||','||
-        spfile ||','||
-        patchLevel ||','||
-        cpuCount ||','||
-        racEnabled ||','||
-        sgaMaxSize ||','||
-        sgaTarget ||','||
-        pgaAggregateTarget ||','||
-        physMemory ||','||
-        dNFSenabled ||','||
-        GoldenGate ||','||
-        exadataEnabled ||','||
-        bctEnabled ||','||
-        LogArchiveConfig ||','||
-        ArchiveLagTarget ||','||
-        logfileCount ||','||
+-- 20240827 - changing column seperator to prevent data shift due to DG setting in LogArchiveConfig - smcelhinney 
+select con_id ||',,'||
+        conName ||',,'||
+        dbSizeMB ||',,'||
+        allocated_dbSizeMB ||',,'||
+        dailyChangeRate ||',,'||
+        dailyRedoSize ||',,'||
+        datafileCount ||',,'||
+        tablespaceCount ||',,'||
+        encryptedTablespaceCount ||',,'||
+        encryptedDataSizeMB ||',,'||
+        biggestBigfileMB ||',,'||
+        bigfileTablespaceCount ||',,'||
+        bigfileDataSizeMB ||',,'||
+        blockSize ||',,'||
+        hostName ||',,'||
+        instName ||',,'||
+        dbVersion ||',,'||
+        dbEdition ||',,'||
+        platformName ||',,'||
+        dbName ||',,'||
+        dbUniqueName ||',,'||
+        dbID ||',,'||
+        flashbackEnabled ||',,'||
+        archiveLogEnabled ||',,'||
+        spfile ||',,'||
+        patchLevel ||',,'||
+        cpuCount ||',,'||
+        racEnabled ||',,'||
+        sgaMaxSize ||',,'||
+        sgaTarget ||',,'||
+        pgaAggregateTarget ||',,'||
+        physMemory ||',,'||
+        dNFSenabled ||',,'||
+        GoldenGate ||',,'||
+        exadataEnabled ||',,'||
+        bctEnabled ||',,'||
+        LogArchiveConfig ||',,'||
+        ArchiveLagTarget ||',,'||
+        logfileCount ||',,'||
         tempfileCount
  from rubrikDataCollection;
 

--- a/ORACLE/rbkDataCollection_11g.sql
+++ b/ORACLE/rbkDataCollection_11g.sql
@@ -274,7 +274,7 @@ commit;
 
 -- format data collected for json output
 set linesize 32000
-set colsep ,
+set colsep ,,
 set headsep off
 set head off
 set trimspool on
@@ -286,45 +286,46 @@ set wrap off
 spool rbkDiscovery.csv append
 
 -- 20230322 - reordering query output to logically group data - smcelhinney
-select con_id ||','||
-        conName ||','||
-        dbSizeMB ||','||
-        allocated_dbSizeMB ||','||
-        dailyChangeRate ||','||
-        dailyRedoSize ||','||
-        datafileCount ||','||
-        tablespaceCount ||','||
-        encryptedTablespaceCount ||','||
-        encryptedDataSizeMB ||','||
-        biggestBigfileMB ||','||
-        bigfileTablespaceCount ||','||
-        bigfileDataSizeMB ||','||
-        blockSize ||','||
-        hostName ||','||
-        instName ||','||
-        dbVersion ||','||
-        dbEdition ||','||
-        platformName ||','||
-        dbName ||','||
-        dbUniqueName ||','||
-        dbID ||','||
-        flashbackEnabled ||','||
-        archiveLogEnabled ||','||
-        spfile ||','||
-        patchLevel ||','||
-        cpuCount ||','||
-        racEnabled ||','||
-        sgaMaxSize ||','||
-        sgaTarget ||','||
-        pgaAggregateTarget ||','||
-        physMemory ||','||
-        dNFSenabled ||','||
-        GoldenGate ||','||
-        exadataEnabled ||','||
-        bctEnabled ||','||
-        LogArchiveConfig ||','||
-        ArchiveLagTarget ||','||
-        logfileCount ||','||
+-- 20240827 - changing column separator to prevent data shift due to DG setting in LogArchiveConfig - smcelhinney
+select con_id ||',,'||
+        conName ||',,'||
+        dbSizeMB ||',,'||
+        allocated_dbSizeMB ||',,'||
+        dailyChangeRate ||',,'||
+        dailyRedoSize ||',,'||
+        datafileCount ||',,'||
+        tablespaceCount ||',,'||
+        encryptedTablespaceCount ||',,'||
+        encryptedDataSizeMB ||',,'||
+        biggestBigfileMB ||',,'||
+        bigfileTablespaceCount ||',,'||
+        bigfileDataSizeMB ||',,'||
+        blockSize ||',,'||
+        hostName ||',,'||
+        instName ||',,'||
+        dbVersion ||',,'||
+        dbEdition ||',,'||
+        platformName ||',,'||
+        dbName ||',,'||
+        dbUniqueName ||',,'||
+        dbID ||',,'||
+        flashbackEnabled ||',,'||
+        archiveLogEnabled ||',,'||
+        spfile ||',,'||
+        patchLevel ||',,'||
+        cpuCount ||',,'||
+        racEnabled ||',,'||
+        sgaMaxSize ||',,'||
+        sgaTarget ||',,'||
+        pgaAggregateTarget ||',,'||
+        physMemory ||',,'||
+        dNFSenabled ||',,'||
+        GoldenGate ||',,'||
+        exadataEnabled ||',,'||
+        bctEnabled ||',,'||
+        LogArchiveConfig ||',,'||
+        ArchiveLagTarget ||',,'||
+        logfileCount ||',,'||
         tempfileCount
  from rubrikDataCollection;
 

--- a/ORACLE/rbkDataCollection_121.sql
+++ b/ORACLE/rbkDataCollection_121.sql
@@ -358,7 +358,7 @@ commit;
 -- format data collected for csv output
 --set markup csv on
 set linesize 32000
-set colsep ,
+set colsep ,,
 set headsep off
 set head off
 set trimspool on
@@ -371,45 +371,46 @@ spool rbkDiscovery.csv append
 
 -- select * from rubrikDataCollection;
 -- 20230322 - reordering query output to logically group data - smcelhinney
-select con_id ||','||
-        conName ||','||
-        dbSizeMB ||','||
-        allocated_dbSizeMB ||','||
-        dailyChangeRate ||','||
-        dailyRedoSize ||','||
-        datafileCount ||','||
-        tablespaceCount ||','||
-        encryptedTablespaceCount ||','||
-        encryptedDataSizeMB ||','||
-        biggestBigfileMB ||','||
-        bigfileTablespaceCount ||','||
-        bigfileDataSizeMB ||','||
-        blockSize ||','||
-        hostName ||','||
-        instName ||','||
-        dbVersion ||','||
-        dbEdition ||','||
-        platformName ||','||
-        dbName ||','||
-        dbUniqueName ||','||
-        dbID ||','||
-        flashbackEnabled ||','||
-        archiveLogEnabled ||','||
-        spfile ||','||
-        patchLevel ||','||
-        cpuCount ||','||
-        racEnabled ||','||
-        sgaMaxSize ||','||
-        sgaTarget ||','||
-        pgaAggregateTarget ||','||
-        physMemory ||','||
-        dNFSenabled ||','||
-        GoldenGate ||','||
-        exadataEnabled ||','||
-        bctEnabled ||','||
-        LogArchiveConfig ||','||
-        ArchiveLagTarget ||','||
-        logfileCount ||','||
+-- 20240827 - changing column seperator to prevent data shift due to DG setting in LogArchiveConfig - smcelhinney 
+select con_id ||',,'||
+        conName ||',,'||
+        dbSizeMB ||',,'||
+        allocated_dbSizeMB ||',,'||
+        dailyChangeRate ||',,'||
+        dailyRedoSize ||',,'||
+        datafileCount ||',,'||
+        tablespaceCount ||',,'||
+        encryptedTablespaceCount ||',,'||
+        encryptedDataSizeMB ||',,'||
+        biggestBigfileMB ||',,'||
+        bigfileTablespaceCount ||',,'||
+        bigfileDataSizeMB ||',,'||
+        blockSize ||',,'||
+        hostName ||',,'||
+        instName ||',,'||
+        dbVersion ||',,'||
+        dbEdition ||',,'||
+        platformName ||',,'||
+        dbName ||',,'||
+        dbUniqueName ||',,'||
+        dbID ||',,'||
+        flashbackEnabled ||',,'||
+        archiveLogEnabled ||',,'||
+        spfile ||',,'||
+        patchLevel ||',,'||
+        cpuCount ||',,'||
+        racEnabled ||',,'||
+        sgaMaxSize ||',,'||
+        sgaTarget ||',,'||
+        pgaAggregateTarget ||',,'||
+        physMemory ||',,'||
+        dNFSenabled ||',,'||
+        GoldenGate ||',,'||
+        exadataEnabled ||',,'||
+        bctEnabled ||',,'||
+        LogArchiveConfig ||',,'||
+        ArchiveLagTarget ||',,'||
+        logfileCount ||',,'||
         tempfileCount
  from rubrikDataCollection;
 

--- a/ORACLE/rbkDataCollection_12c.sql
+++ b/ORACLE/rbkDataCollection_12c.sql
@@ -359,7 +359,7 @@ commit;
 -- format data collected for csv output
 --set markup csv on
 set linesize 32000
-set colsep ,
+set colsep ,,
 set headsep off
 set head off
 set trimspool on
@@ -372,45 +372,46 @@ spool rbkDiscovery.csv append
 
 -- select * from rubrikDataCollection;
 -- 20230322 - reordering query output to logically group data - smcelhinney
-select con_id ||','||
-        conName ||','||
-        dbSizeMB ||','||
-        allocated_dbSizeMB ||','||
-        dailyChangeRate ||','||
-        dailyRedoSize ||','||
-        datafileCount ||','||
-        tablespaceCount ||','||
-        encryptedTablespaceCount ||','||
-        encryptedDataSizeMB ||','||
-        biggestBigfileMB ||','||
-        bigfileTablespaceCount ||','||
-        bigfileDataSizeMB ||','||
-        blockSize ||','||
-        hostName ||','||
-        instName ||','||
-        dbVersion ||','||
-        dbEdition ||','||
-        platformName ||','||
-        dbName ||','||
-        dbUniqueName ||','||
-        dbID ||','||
-        flashbackEnabled ||','||
-        archiveLogEnabled ||','||
-        spfile ||','||
-        patchLevel ||','||
-        cpuCount ||','||
-        racEnabled ||','||
-        sgaMaxSize ||','||
-        sgaTarget ||','||
-        pgaAggregateTarget ||','||
-        physMemory ||','||
-        dNFSenabled ||','||
-        GoldenGate ||','||
-        exadataEnabled ||','||
-        bctEnabled ||','||
-        LogArchiveConfig ||','||
-        ArchiveLagTarget ||','||
-        logfileCount ||','||
+-- 20240827 - changing column seperator to prevent data shift due to DG setting in LogArchiveConfig - smcelhinney 
+select con_id ||',,'||
+        conName ||',,'||
+        dbSizeMB ||',,'||
+        allocated_dbSizeMB ||',,'||
+        dailyChangeRate ||',,'||
+        dailyRedoSize ||',,'||
+        datafileCount ||',,'||
+        tablespaceCount ||',,'||
+        encryptedTablespaceCount ||',,'||
+        encryptedDataSizeMB ||',,'||
+        biggestBigfileMB ||',,'||
+        bigfileTablespaceCount ||',,'||
+        bigfileDataSizeMB ||',,'||
+        blockSize ||',,'||
+        hostName ||',,'||
+        instName ||',,'||
+        dbVersion ||',,'||
+        dbEdition ||',,'||
+        platformName ||',,'||
+        dbName ||',,'||
+        dbUniqueName ||',,'||
+        dbID ||',,'||
+        flashbackEnabled ||',,'||
+        archiveLogEnabled ||',,'||
+        spfile ||',,'||
+        patchLevel ||',,'||
+        cpuCount ||',,'||
+        racEnabled ||',,'||
+        sgaMaxSize ||',,'||
+        sgaTarget ||',,'||
+        pgaAggregateTarget ||',,'||
+        physMemory ||',,'||
+        dNFSenabled ||',,'||
+        GoldenGate ||',,'||
+        exadataEnabled ||',,'||
+        bctEnabled ||',,'||
+        LogArchiveConfig ||',,'||
+        ArchiveLagTarget ||',,'||
+        logfileCount ||',,'||
         tempfileCount
  from rubrikDataCollection;
 


### PR DESCRIPTION
Updated sql scripts to use a new column separator to prevent csv conversion issues with DG definitions in LogArchiveConfig column