### PR TITLE
Add s3:GetBucketTagging to role CFT

### DIFF
--- a/CLOUD/Get-AWSSizingInfo-Permissions.cft
+++ b/CLOUD/Get-AWSSizingInfo-Permissions.cft
@@ -60,6 +60,7 @@ Resources:
                   - 'rds:DescribeDBInstances'
                   - 's3:GetBucketLocation'
                   - 's3:ListAllMyBuckets'
+                  - 's3:GetBucketTagging'
                   - 'secretsmanager:ListSecrets'
                   - 'sts:AssumeRole'
                   - 'sqs:ListQueues'

--- a/CLOUD/README.md
+++ b/CLOUD/README.md
@@ -77,6 +77,7 @@ To run the AWS sizing script, ensure you have the following:
                       "rds:DescribeDBInstances",
                       "s3:GetBucketLocation",
                       "s3:ListAllMyBuckets",
+                      "s3:GetBucketTagging",
                       "secretsmanager:ListSecrets",
                       "sts:AssumeRole",
                       "sqs:ListQueues"


### PR DESCRIPTION
Most current version of the AWS sizing script requires s3:GetBucketTagging for the cross account role created via the included CloudFormation Template.