### PR TITLE
Fix: -Operator flag no longer recognized in module

### DIFF
--- a/CLOUD/Get-AzureSizingInfo.ps1
+++ b/CLOUD/Get-AzureSizingInfo.ps1
@@ -1389,7 +1389,7 @@ foreach ($sub in $subs) {
     $TimePeriodFrom = [datetime]::Parse($startDate)
     $TimePeriodTo = [datetime]::Parse($endDate)
     try{
-      $dimensions = New-AzCostManagementQueryComparisonExpressionObject -Name 'ServiceName' -Value 'Backup' -Operator ""
+      $dimensions = New-AzCostManagementQueryComparisonExpressionObject -Name 'ServiceName' -Value 'Backup'
       $filter = New-AzCostManagementQueryFilterObject -Dimensions $dimensions
     
       $aggregation = @{                                                                                                                                                             


### PR DESCRIPTION
On line 1383, using the -Operator "" flag has resulted in errors across multiple environments.

This change removes the flag to allow the module to correctly gather backup information without triggering the issue.