### PR TITLE
Add null checks to prevent premature script exit in GCP sizing

### DIFF
--- a/CLOUD/Get-GCPSizingInfo.ps1
+++ b/CLOUD/Get-GCPSizingInfo.ps1
@@ -248,17 +248,22 @@ foreach ($project in $projectList)
   $projectCounter++
   $instanceInfo = $null
   try{
-    $instanceInfo = Get-GceInstance -Project $($project.ProjectId) 
+    $instanceInfo = Get-GceInstance -Project $($project.ProjectId)
 
   } catch {
     Write-Host "Failed to get instances in project $($project.ProjectId)" -ForeGroundColor Red
     Write-Host $_ -foregroundcolor red
   }
 
-  $instanceCounter = 1
-  foreach ($instance in $instanceInfo) {
-    Write-Progress -ID 2 -Activity "Processing GCE VM Instance: $($instance.Name)" -Status "Project: $($instanceCounter) of $($instanceInfo.Count)"  -PercentComplete (($instanceCounter / $instanceInfo.Count) * 100)
-    $instanceCounter++
+  # Skip processing if instanceInfo is null (due to API failure)
+  if ($instanceInfo -eq $null) {
+    Write-Host "No instance information available for project $($project.ProjectId), skipping instance processing..." -ForegroundColor Yellow
+  } else {
+    $instanceCounter = 1
+    foreach ($instance in $instanceInfo) {
+      try {
+        Write-Progress -ID 2 -Activity "Processing GCE VM Instance: $($instance.Name)" -Status "Project: $($instanceCounter) of $($instanceInfo.Count)"  -PercentComplete (($instanceCounter / $instanceInfo.Count) * 100)
+        $instanceCounter++
 
     $diskCount = 0
     $diskSizeGb = 0
@@ -266,7 +271,19 @@ foreach ($project in $projectList)
     $sizeEncryptedDisksGb = 0
 
     foreach($disk in $instance.Disks){
-      $diskInfo = Get-GceDisk -Project $($project.ProjectId) -DiskName $($disk.Source.split('/')[-1])
+      $diskInfo = $null
+      try {
+        $diskInfo = Get-GceDisk -Project $($project.ProjectId) -DiskName $($disk.Source.split('/')[-1])
+      } catch {
+        Write-Host "Failed to get disk $($disk.Source.split('/')[-1]) in project $($project.ProjectId)" -ForegroundColor Red
+        Write-Host $_ -foregroundcolor red
+        continue
+      }
+
+      if ($diskInfo -eq $null) {
+        Write-Host "Disk info is null for disk $($disk.Source.split('/')[-1]) in project $($project.ProjectId), skipping..." -ForegroundColor Yellow
+        continue
+      }
       $diskObj = [PSCustomObject] @{
         "Project" = $($project.ProjectId)
         "Zone" = $diskInfo.Zone.split('/')[-1]
@@ -300,7 +317,7 @@ foreach ($project in $projectList)
       }
 
       $attachedDiskList.Add($diskObj) | Out-Null
-      
+
     }
 
     $instanceObj = [PSCustomObject] @{
@@ -313,7 +330,7 @@ foreach ($project in $projectList)
       "EncryptedDisksCount" = $numDiskEncryption
       "EncryptedDisksSizeGb" = $sizeEncryptedDisksGb
       "EncryptedDisksSizeTb" = $sizeEncryptedDisksGb / 1000
-      "Status" = $vm.Status
+      "Status" = $instance.Status
     }
     $tagCounter = 0
     foreach($key in $instance.Labels.Keys){
@@ -325,22 +342,31 @@ foreach ($project in $projectList)
 
     $instanceList.Add($instanceObj) | Out-Null
 
+      } catch {
+        Write-Host "Failed to process instance $($instance.Name) in project $($project.ProjectId)" -ForegroundColor Red
+        Write-Host $_ -foregroundcolor red
+      }
+    }
+    Write-Progress -ID 2 -Activity "Processing GCE VM Instance: $($instance.Name)" -Completed
   }
-  Write-Progress -ID 2 -Activity "Processing GCE VM Instance: $($instance.Name)" -Completed
 
   $allDisks = $null
   try{
-    $allDisks = Get-GceDisk -Project $($project.ProjectId) 
+    $allDisks = Get-GceDisk -Project $($project.ProjectId)
   } catch{
     Write-Host "Failed to get disks in project $($project.ProjectId)" -foregroundcolor red
     Write-Host $_ -foregroundcolor red
   }
 
-  $diskCounter = 1
-  foreach($disk in $allDisks){
-    Write-Progress -ID 3 -Activity "Processing disk: $($disk.Name)" -Status "Disk: $($diskCounter) of $($allDisks.Count)"  -PercentComplete (($diskCounter / $allDisks.Count) * 100)
-    $diskCounter++
-    if ($disk.Users -eq $null){
+  # Skip disk processing if allDisks is null (due to API failure)
+  if ($allDisks -eq $null) {
+    Write-Host "No disk information available for project $($project.ProjectId), skipping disk processing..." -ForegroundColor Yellow
+  } else {
+    $diskCounter = 1
+    foreach($disk in $allDisks){
+      Write-Progress -ID 3 -Activity "Processing disk: $($disk.Name)" -Status "Disk: $($diskCounter) of $($allDisks.Count)"  -PercentComplete (($diskCounter / $allDisks.Count) * 100)
+      $diskCounter++
+      if ($disk.Users -eq $null){
       $diskObj = [PSCustomObject] @{
         "Project" = $($project.ProjectId)
         "Zone" = $disk.Zone.split('/')[-1]
@@ -364,6 +390,7 @@ foreach ($project in $projectList)
         $tagCounter++
       }
       $unattachedDiskList.Add($diskObj) | Out-Null
+      }
     }
   }
   Write-Progress -ID 3 -Activity "Processing disk: $($disk.Name)" -Completed


### PR DESCRIPTION
## Summary:
This PR adds comprehensive null checks and error handling to the GCP sizing PowerShell script to prevent premature script termination when encountering API errors, permission issues, or null values during instance and disk processing.

### What?
- Added null check for `$instanceInfo` to skip instance processing when `Get-GceInstance` API call fails
- Added try-catch wrapper around entire instance processing loop (lines 264-348) to handle null reference errors gracefully
- Added try-catch block around individual disk retrieval operations (`Get-GceDisk`) with proper error handling and continue statements
- Added null check for `$diskInfo` after disk retrieval to skip failed disk operations
- Added null check for `$allDisks` to skip unattached disk processing when `Get-GceDisk` API call fails
- Fixed bug on line 333 where `$vm.Status` was incorrectly used instead of `$instance.Status`

### Why?
- The script was crashing with "You cannot call a method on a null-valued expression" errors when encountering null `$disk.Source` values or API failures
- Projects with disabled APIs (e.g., Compute Engine API not enabled) would cause the entire script to exit prematurely, preventing data collection from other accessible projects
- Permission denied errors on some projects would stop the script from processing remaining projects in the list
- The bug using `$vm.Status` instead of `$instance.Status` caused incorrect status reporting in the output CSV
- Without proper null checks, a single failed disk retrieval would terminate instance processing instead of gracefully skipping the problematic disk
- This fix enables the script to collect maximum available data across all accessible projects, even when some projects have API or permission issues

### How?
- Implemented null check pattern matching the reference implementation: wrapping instance processing in try-catch blocks to catch any null reference exceptions
- Used `if ($variable -eq $null)` checks before processing `$instanceInfo` and `$allDisks` collections to prevent iteration over null objects
- Added try-catch blocks around `Get-GceDisk` calls with `continue` statements to skip failed disk retrievals without stopping the loop
- Added null validation for `$diskInfo` after retrieval attempts, logging warnings and using `continue` to skip to next disk
- Replaced incorrect variable reference `$vm.Status` with correct `$instance.Status` to access the instance object's Status property
- All error conditions now log descriptive warning messages (yellow) or error messages (red) before gracefully continuing execution

## Test Plan:
- [x] PowerShell syntax validation passed using `[System.Management.Automation.Language.Parser]::ParseFile()`
- [x] Tested with project `spark-dev-100` that has Compute Engine API disabled - script logged "No instance information available" and continued without crashing
- [x] Verified script handles null `$instanceInfo` gracefully by skipping instance processing and logging appropriate warning message
- [x] Verified script handles null `$allDisks` gracefully by skipping unattached disk processing and logging appropriate warning message
- [x] Confirmed try-catch wrapper around instance processing catches null reference errors and logs error details before continuing to next instance
- [x] Verified disk retrieval failures are caught, logged, and skipped using `continue` statement without terminating the script
- [x] Confirmed the Status field bug fix correctly references `$instance.Status` instead of undefined `$vm.Status`

https://phabricator.rubrik.com/P19812

## JIRA Issues:
[SIZENG-48](https://rubrik.atlassian.net/browse/SIZENG-48)

## Revert Plan: