### PR TITLE
fix: guard against null backup costs in GovCloud

### DIFF
--- a/CLOUD/Get-AWSSizingInfo.ps1
+++ b/CLOUD/Get-AWSSizingInfo.ps1
@@ -2490,13 +2490,15 @@ $s3TotalTBsFormatted  = $s3TotalTBs.GetEnumerator() |
   $totalKeys = ($kmsList.Keys | Measure-Object -Sum).sum
   $totalQueues = ($sqsList.Queues | Measure-Object -Sum).sum
 
-  # If statement is a workaround for error when getting backup plans when payer account 
-  # does not allow access for linked accounts
-  if ($null -eq $backupCostsList.AWSBackupNetUnblendedCost) {
+  $backupTotalNetUnblendedCost = 0
+  if ($backupCostsList.Count -eq 0 -or $null -eq $backupCostsList.AWSBackupNetUnblendedCost) {
     Write-Error "No AWS Backup costs found."
     Write-Error "AWS Cost data not reported"
   } else {
-    $backupTotalNetUnblendedCost = ($backupCostsList.AWSBackupNetUnblendedCost | ForEach-Object { [decimal]($_.TrimStart('$')) } | Measure-Object -Sum).sum
+    $backupTotalNetUnblendedCost = ($backupCostsList.AWSBackupNetUnblendedCost |
+      Where-Object { $null -ne $_ } |
+      ForEach-Object { [decimal]($_.TrimStart('$')) } |
+      Measure-Object -Sum).Sum
   }
 
 function addTagsToAllObjectsInList($list) {


### PR DESCRIPTION
## Summary
- Initializes `$backupTotalNetUnblendedCost` to 0 so the summary line doesn't show blank when Cost Explorer is unavailable
- Adds `Where-Object { $null -ne $_ }` filter before `TrimStart('$')` to prevent null reference crash
- Adds `$backupCostsList.Count -eq 0` check alongside the existing null check for robustness

The Cost Explorer endpoint (`ce.<region>.amazonaws.com`) doesn't exist in all GovCloud regions, causing the script to crash with "You cannot call a method on a null-valued expression" when it tries to parse cost strings.

Closes #80

## Test plan
- [ ] Run `Get-AWSSizingInfo.ps1 -Partition GovCloud` against an account with access to `us-gov-west-1` and `us-gov-east-1`
- [ ] Verify script completes without crash when CE is unavailable in a region
- [ ] Confirm cost summary shows `$0` instead of crashing or showing blank

🤖 Generated with [Claude Code](https://claude.com/claude-code)