### PR TITLE
fix: resolve management group display names to IDs

### DIFF
--- a/CLOUD/Get-AzureSizingInfo.ps1
+++ b/CLOUD/Get-AzureSizingInfo.ps1
@@ -74,7 +74,8 @@ may take a long time when large blob stores are located.
 
 
 .PARAMETER ManagementGroups
-A comma separated list of Azure Management Groups to gather data from.
+A comma separated list of Azure Management Group IDs or display names to gather data from.
+If a display name is provided, the script will attempt to resolve it to the management group ID.
 
 .PARAMETER GetKeyVaultAmounts
 Gets number of key vaults, and amount of certificates, keys, and secrets in each key vault. One must add the
@@ -581,9 +582,22 @@ switch ($PSCmdlet.ParameterSetName) {
     $subs = @()
     foreach ($managementGroup in ($ManagementGroups -split ',' | ForEach-Object { $_.Trim() })) {
       try {
+        # Search-AzGraph requires the management group ID, not the display name.
+        # Attempt to resolve the input as a display name first.
+        $mgId = $managementGroup
+        try {
+          $allMGs = Get-AzManagementGroup -ErrorAction Stop
+          $match = $allMGs | Where-Object { $_.DisplayName -eq $managementGroup }
+          if ($match) {
+            $mgId = $match.Name
+            Write-Host "Resolved management group display name '$managementGroup' to ID '$mgId'" -ForegroundColor Green
+          }
+        } catch {
+          Write-Host "Could not query management groups to resolve display name, using '$managementGroup' as-is" -ForegroundColor Yellow
+        }
         $subscriptionNames = $(Search-AzGraph `
           -Query "ResourceContainers | where type =~ 'microsoft.resources/subscriptions'" `
-          -ManagementGroup $managementGroup -ErrorAction Stop).name
+          -ManagementGroup $mgId -ErrorAction Stop).name
         foreach ($subName in $subscriptionNames) {
           $sub = Get-AzSubscription -TenantId $context.Tenant.Id -SubscriptionName $subName -ErrorAction Stop
           $subs += $sub

--- a/CLOUD/Get-AzureSizingInfo.ps1
+++ b/CLOUD/Get-AzureSizingInfo.ps1
@@ -75,7 +75,8 @@ may take a long time when large blob stores are located.
 
 
 .PARAMETER ManagementGroups
-A comma separated list of Azure Management Groups to gather data from.
+A comma separated list of Azure Management Group IDs or display names to gather data from.
+If a display name is provided, the script will attempt to resolve it to the management group ID.
 
 .PARAMETER GetKeyVaultAmounts
 Gets number of key vaults, and amount of certificates, keys, and secrets in each key vault. One must add the
@@ -1777,9 +1778,22 @@ switch ($PSCmdlet.ParameterSetName) {
     $subs = @()
     foreach ($managementGroup in ($ManagementGroups -split ',' | ForEach-Object { $_.Trim() })) {
       try {
+        # Search-AzGraph requires the management group ID, not the display name.
+        # Attempt to resolve the input as a display name first.
+        $mgId = $managementGroup
+        try {
+          $allMGs = Get-AzManagementGroup -ErrorAction Stop
+          $match = $allMGs | Where-Object { $_.DisplayName -eq $managementGroup }
+          if ($match) {
+            $mgId = $match.Name
+            Write-Host "Resolved management group display name '$managementGroup' to ID '$mgId'" -ForegroundColor Green
+          }
+        } catch {
+          Write-Host "Could not query management groups to resolve display name, using '$managementGroup' as-is" -ForegroundColor Yellow
+        }
         $subscriptionNames = $(Search-AzGraph `
           -Query "ResourceContainers | where type =~ 'microsoft.resources/subscriptions'" `
-          -ManagementGroup $managementGroup -ErrorAction Stop).name
+          -ManagementGroup $mgId -ErrorAction Stop).name
         foreach ($subName in $subscriptionNames) {
           $sub = Get-AzSubscription -TenantId $context.Tenant.Id -SubscriptionName $subName -ErrorAction Stop
           $subs += $sub


### PR DESCRIPTION
## Summary
- `Search-AzGraph -ManagementGroup` requires the group **ID** (e.g., `mg-root`), not the **display name** (e.g., `Tenant Root Group`)
- The script now queries `Get-AzManagementGroup` to resolve display names to IDs before calling `Search-AzGraph`
- Falls back to using the input as-is if resolution fails (so existing users passing IDs are unaffected)
- Updated parameter help to clarify both IDs and display names are accepted

Closes #87

## Test plan
- [ ] Run `Get-AzureSizingInfo.ps1 -ManagementGroups "Tenant Root Group"` — should resolve and succeed
- [ ] Run `Get-AzureSizingInfo.ps1 -ManagementGroups "<actual-mg-id>"` — should work as before
- [ ] Run with a non-existent name — should fall back and show the original Azure error

🤖 Generated with [Claude Code](https://claude.com/claude-code)