### PR TITLE
Add IDENTITY scripts for AD and Entra ID human identity auditing

### DIFF
--- a/IDENTITY/.gitignore
+++ b/IDENTITY/.gitignore
@@ -1,0 +1,5 @@
+*
+!.gitignore
+!Get-AdHumanIdentity.ps1
+!Get-EntraHumanIdentity.ps1
+!README.md

--- a/IDENTITY/Get-AdHumanIdentity.ps1
+++ b/IDENTITY/Get-AdHumanIdentity.ps1
@@ -15,12 +15,32 @@
         - Accounts with passwords set to never expire.
         - Accounts matching specific naming patterns (e.g., "svc_*").
     - **Reporting Granularity**: Offers two levels of reporting to provide flexibility in how the data is presented:
-        - **UserPerOU**: A detailed report with counts broken down by each Organizational Unit (OU).
+        - **Full**: A detailed report with counts broken down by each Organizational Unit (OU).
         - **Summary**: A high-level report with aggregated counts for each domain.
 
-    The script generates a CSV report that can be shared with Rubrik for licensing purposes.
-    
-    Author : Aymeric Jaouen
+    The script generates CSV and HTML reports that can be shared with Rubrik for licensing purposes.
+
+    ## Report Columns
+
+    ### Per-OU Report (ByOU)
+    - **Domain**: The Active Directory domain name.
+    - **OU**: The Organizational Unit distinguished name.
+    - **Total Users**: Total number of user accounts in this OU (includes enabled user accounts plus MSA/gMSA service accounts).
+    - **Active Users**: Number of accounts that have logged in within the last 180 days.
+    - **Inactive Users**: Number of accounts that have not logged in within the last 180 days.
+    - **Never Logged In Users**: Number of accounts with no recorded logon event.
+    - **Managed Service Accounts**: Number of Managed Service Accounts (MSA).
+    - **Group Managed Service Accounts**: Number of Group Managed Service Accounts (gMSA).
+    - **Password Never Expires**: Number of enabled accounts with the PasswordNeverExpires flag set.
+    - **Pattern Matched Service Accounts**: Number of accounts matching the -UserServiceAccountNamesLike patterns.
+    - **Licensed Identities**: Number of users qualifying for Rubrik licensing (Active + not MSA + not gMSA + not pattern-matched service account).
+
+    ### Per-Domain Report (ByDomain)
+    Same columns as ByOU, minus the OU column. Values are aggregated across all OUs for each domain.
+
+    ### Licensing Report
+    - **Domain**: The Active Directory domain name.
+    - **Licensed Identities**: Number of users qualifying for Rubrik licensing. Formula: Active + not MSA + not gMSA + not pattern-matched.
 
 .PARAMETER SpecificDomains
     This is an optional parameter that allows you to specify which Active Directory domains to audit. If you do not use this parameter, the script will automatically discover and audit all domains in the current AD forest.
@@ -34,23 +54,30 @@
     This is useful for identifying service accounts that are not formally registered as MSAs or gMSAs.
     Example: -UserServiceAccountNamesLike "*svc*", "*_bot", "testuser*"
 
+.PARAMETER ExcludeOUs
+    This is an optional parameter that allows you to exclude specific Organizational Units (OUs) from the audit. Any user account located in one of the specified OUs will be completely ignored and not counted in any report column.
+
+    The match is exact on the OU distinguished name (the part of the user's DN after the first comma). You can find the OU DN by running: Get-ADUser -Identity "someuser" | Select-Object DistinguishedName
+
+    Example: -ExcludeOUs "OU=Servers,DC=corp,DC=local", "OU=Equipment,OU=Resources,DC=corp,DC=local"
+
 .PARAMETER Mode
     This is a required parameter that controls the level of detail in the final report. You must choose one of the following two modes:
-    - 'UserPerOU': This mode provides a very detailed report, with a separate entry for each Organizational Unit (OU). This is the recommended mode for a granular analysis.
+    - 'Full': This mode provides a very detailed report, with a separate entry for each Organizational Unit (OU). This is the recommended mode for a granular analysis.
     - 'Summary': This mode provides a high-level overview, with a single entry for each domain, showing the total counts for all account types.
 
-    The default value is 'UserPerOU'.
+    The default value is 'Full'.
 
 .EXAMPLE
     Example 1: Perform a detailed audit of the entire forest and identify service accounts by name.
 
-    .\Get-AdHumanIdentity.ps1 -UserServiceAccountNamesLike "*svc*", "*_app" -Mode UserPerOU
+    .\Get-AdHumanIdentity.ps1 -UserServiceAccountNamesLike "*svc*", "*_app" -Mode Full
 
     This command will:
     - Scan all domains in the current AD forest.
     - Flag any user account with a name containing "svc" or "_app" as a service account.
     - Generate a detailed report with account counts for each OU.
-    - Save the report to a CSV file in the .\ADReports directory.
+    - Save the reports in CSV and HTML format in the .\ADReports directory.
 
 .EXAMPLE
     Example 2: Perform a summary audit of a single, specific domain.
@@ -60,21 +87,25 @@
     This command will:
     - Connect only to the "corp.example.com" domain.
     - Generate a high-level summary report for that domain.
-    - Save the report to a CSV file in the .\ADReports directory.
+    - Save the reports in CSV and HTML format in the .\ADReports directory.
 
 .NOTES
     - **Prerequisites**: The computer running this script must have the Active Directory module for PowerShell installed. This is part of the Remote Server Administration Tools (RSAT).
     - **Permissions**: The user account running this script must have read permissions for user and service account objects in the target Active Directory domains.
     - **Execution Policy**: You may need to adjust the PowerShell execution policy to run this script. You can do this by running "Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope Process".
     - **Culture Settings**: The script temporarily sets the culture to 'en-US' to ensure that dates and times are parsed correctly. This change is reverted at the end of the script.
+
+.AUTOR
+    Aymeric Jaouen
 #>
 
 
 param (
     [string[]]$UserServiceAccountNamesLike = @(),
     [string[]]$SpecificDomains,
-    [ValidateSet("UserPerOU", "Summary")]
-    [string]$Mode = "UserPerOU"
+    [string[]]$ExcludeOUs = @(),
+    [ValidateSet("Full", "Summary")]
+    [string]$Mode = "Full"
 )
 
 # === Logging Setup ===
@@ -91,6 +122,31 @@ function Write-Log {
     $formatted = "[{0}] [{1}] {2}" -f (Get-Date -Format "yyyy-MM-dd HH:mm:ss"), $Level, $Message
     Add-Content -Path $logPath -Value $formatted
     Write-Host $Message
+}
+
+# === Log the command that started the script ===
+try {
+    $commandString = $MyInvocation.MyCommand.Name
+    foreach ($param in $MyInvocation.BoundParameters.GetEnumerator()) {
+        $paramName = $param.Key
+        $paramValue = $param.Value
+
+        $formattedValue = ""
+        if ($paramValue -is [System.Array]) {
+            $formattedValue = '"' + ($paramValue -join '", "') + '"'
+        } elseif ($paramValue -is [string] -and $paramValue.Contains(" ")) {
+            $formattedValue = """$paramValue"""
+        } else {
+            $formattedValue = $paramValue.ToString()
+        }
+        $commandString += " -$paramName $formattedValue"
+    }
+    $script:commandLine = $commandString
+    Write-Log "Script started with command: $commandString" "INFO"
+}
+catch {
+    $script:commandLine = "N/A"
+    Write-Log "Could not log the command line. Error: $_" "WARNING"
 }
 
 function Initialize-Prerequisites {
@@ -120,18 +176,69 @@ function Initialize-Prerequisites {
     [System.Threading.Thread]::CurrentThread.CurrentCulture = 'en-US'
     [System.Threading.Thread]::CurrentThread.CurrentUICulture = 'en-US'
 
-    Write-Log "Prerequisites validated. Environment initialized." -ForegroundColor Green
+    Write-Log "Prerequisites validated. Environment initialized."
 }
 
 Initialize-Prerequisites
 
-# =====================
-# Helper Functions
-# =====================
+#==================================================================================================
+# 1. HEADERS
+#==================================================================================================
+function Get-ReportHeaders {
+    param(
+        [Parameter(Mandatory)]
+        [ValidateSet('ByOU', 'ByDomain', 'Licensing')]
+        [string] $Type
+    )
 
+    switch ($Type) {
+        'ByOU' {
+            return [PSCustomObject][ordered]@{
+                Domain                              = 'Domain'
+                OU                                  = 'Organizational Unit'
+                TotalUsers                          = 'Total Users'
+                ActiveUsers                         = 'Active Users'
+                InactiveUsers                       = 'Inactive Users'
+                NeverLoggedInUsers                  = 'Never Logged In'
+                ServiceAccountsManaged              = 'Managed Service Accounts'
+                ServiceAccountsGroupManaged         = 'Group Managed Service Accounts'
+                ServiceAccountsPasswordNeverExpires = 'Password Never Expires'
+                ServiceAccountsPatternMatched       = 'Pattern Matched Service Accounts'
+                LicensedIdentities                  = 'Licensed Identities'
+            }
+        }
+
+        'ByDomain' {
+            return [PSCustomObject][ordered]@{
+                Domain                              = 'Domain'
+                TotalUsers                          = 'Total Users'
+                ActiveUsers                         = 'Active Users'
+                InactiveUsers                       = 'Inactive Users'
+                NeverLoggedInUsers                  = 'Never Logged In'
+                ServiceAccountsManaged              = 'Managed Service Accounts'
+                ServiceAccountsGroupManaged         = 'Group Managed Service Accounts'
+                ServiceAccountsPasswordNeverExpires = 'Password Never Expires'
+                ServiceAccountsPatternMatched       = 'Pattern Matched Service Accounts'
+                LicensedIdentities                  = 'Licensed Identities'
+            }
+        }
+
+        'Licensing' {
+            return [PSCustomObject][ordered]@{
+                Domain             = 'Domain'
+                LicensedIdentities = 'Licensed Identities'
+            }
+        }
+    }
+}
+
+#==================================================================================================
+# 2. HELPERS
+#==================================================================================================
 function Get-OUFromDN {
     param ([string]$dn)
-    ($dn -split '(?<!\\),')[1..($dn.Count - 1)] -join ','
+    $parts = ($dn -split '(?<!\\),')
+    $parts[1..($parts.Count - 1)] -join ','
 }
 
 function Test-ManagedServiceAccount {
@@ -161,12 +268,12 @@ function Get-UsersAsServiceAccount {
     )
 
     if (-not $NamePatterns -or $NamePatterns.Count -eq 0) {
-        return @()  # nothing to do
+        return @()
     }
 
     $subs = @()
     foreach ($pattern in $NamePatterns) {
-        Write-Log "[$Domain] Searching for users like '$pattern'..." -ForegroundColor Yellow
+        Write-Log "[$Domain] Searching for users like '$pattern'..."
         try {
             $usersFound = Get-ADUser -Server $Domain -Filter "Name -like '$($pattern.Trim())'" `
                 -Properties Name, SamAccountName, DistinguishedName, Enabled, LastLogonTimestamp, PasswordNeverExpires, ServicePrincipalName |
@@ -183,133 +290,511 @@ function Get-UsersAsServiceAccount {
     return $subs
 }
 
-# =====================
-# Main Logic
-# =====================
+#==================================================================================================
+# 3. DETAIL: Build ByOU data
+#==================================================================================================
+function Get-ByOUData {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string[]] $DomainsToAudit,
 
+        [Parameter()]
+        [string[]] $ServicePattern = @(),
+
+        [Parameter()]
+        [string[]] $ExcludeOUs = @(),
+
+        [Parameter(Mandatory)]
+        [datetime] $LogonThreshold
+    )
+
+    $summary = @()
+
+    foreach ($domain in $DomainsToAudit) {
+        Write-Log "Auditing domain: $domain"
+
+        try {
+            $MSASet = Get-ADServiceAccount -Server $domain -Filter { ObjectClass -eq 'msDS-ManagedServiceAccount' } |
+                      Select-Object -ExpandProperty SamAccountName
+            $GMSASet = Get-ADServiceAccount -Server $domain -Filter { ObjectClass -eq 'msDS-GroupManagedServiceAccount' } |
+                       Select-Object -ExpandProperty SamAccountName
+            $NoExpireSet = Get-ADUser -Server $domain -Filter { PasswordNeverExpires -eq $true -and Enabled -eq $true } |
+                           Select-Object -ExpandProperty SamAccountName
+
+            $PatternMatches = Get-UsersAsServiceAccount -NamePatterns $ServicePattern -Domain $domain
+            $PatternSet = $PatternMatches.SamAccountName | Sort-Object -Unique
+
+            $userAccounts = Get-ADUser -Server $domain -Filter { Enabled -eq $true } `
+                -Properties SamAccountName, DistinguishedName, LastLogonTimestamp
+
+            $msaObjects  = @(Get-ADServiceAccount -Server $domain -Filter { ObjectClass -eq 'msDS-ManagedServiceAccount' })
+            $gmsaObjects = @(Get-ADServiceAccount -Server $domain -Filter { ObjectClass -eq 'msDS-GroupManagedServiceAccount' })
+
+            $serviceAccounts = $msaObjects + $gmsaObjects | ForEach-Object {
+                [PSCustomObject]@{
+                    SamAccountName     = $_.SamAccountName
+                    DistinguishedName  = $_.DistinguishedName
+                    LastLogonTimestamp = $_.LastLogonTimestamp
+                }
+            }
+
+            $users = $userAccounts + $serviceAccounts
+
+            foreach ($user in $users) {
+                $sam = $user.SamAccountName
+                $ou  = Get-OUFromDN $user.DistinguishedName
+
+                if ($ExcludeOUs -contains $ou) { continue }
+
+                $entry = $summary | Where-Object { $_.Domain -eq $domain -and $_.OU -eq $ou }
+                if (-not $entry) {
+                    $entry = [PSCustomObject]@{
+                        Domain                              = $domain
+                        OU                                  = $ou
+                        TotalUsers                          = 0
+                        ActiveUsers                         = 0
+                        InactiveUsers                       = 0
+                        NeverLoggedInUsers                  = 0
+                        ServiceAccountsManaged              = 0
+                        ServiceAccountsGroupManaged         = 0
+                        ServiceAccountsPasswordNeverExpires = 0
+                        ServiceAccountsPatternMatched       = 0
+                        LicensedIdentities                  = 0
+                    }
+                    $summary += $entry
+                }
+
+                $entry.TotalUsers++
+
+                $isActive = $false
+                if ($user.LastLogonTimestamp) {
+                    if ($user.LastLogonTimestamp -ge $LogonThreshold.ToFileTime()) {
+                        $entry.ActiveUsers++
+                        $isActive = $true
+                    } else {
+                        $entry.InactiveUsers++
+                    }
+                } else {
+                    $entry.NeverLoggedInUsers++
+                }
+
+                $isMSA     = Test-ManagedServiceAccount $sam $MSASet
+                $isGMSA    = Test-GroupManagedServiceAccount $sam $GMSASet
+                $isPattern = Test-PatternMatchedUser $sam $PatternSet
+
+                if ($isMSA)      { $entry.ServiceAccountsManaged++ }
+                elseif ($isGMSA) { $entry.ServiceAccountsGroupManaged++ }
+                if (Test-NonExpiringUser $sam $NoExpireSet) { $entry.ServiceAccountsPasswordNeverExpires++ }
+                if ($isPattern)  { $entry.ServiceAccountsPatternMatched++ }
+
+                if ($isActive -and -not $isMSA -and -not $isGMSA -and -not $isPattern) {
+                    $entry.LicensedIdentities++
+                }
+            }
+
+            Write-Log "Successfully processed domain '$domain'. Found $($users.Count) accounts."
+        } catch {
+            Write-Log "Failed processing domain $domain : $_" "ERROR"
+        }
+    }
+
+    # Build a grand-total row
+    $totals = [ordered]@{ Domain = 'TOTAL'; OU = '' }
+    foreach ($col in $summary | Get-Member -MemberType NoteProperty | Select-Object -Expand Name | Where-Object { $_ -notin @('Domain','OU') }) {
+        $totals[$col] = ($summary | Measure-Object -Property $col -Sum).Sum
+    }
+
+    Write-Log "Successfully built $($summary.Count) OU records across all domains."
+    return $summary + [PSCustomObject]$totals
+}
+
+#==================================================================================================
+# 4. SUMMARY: Group Into ByDomain
+#==================================================================================================
+function Get-ByDomainData {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [object[]] $OUData
+    )
+
+    $rows = $OUData |
+        Group-Object Domain |
+        ForEach-Object {
+            [PSCustomObject][ordered]@{
+                Domain                              = $_.Name
+                TotalUsers                          = ($_.Group | Measure-Object TotalUsers -Sum).Sum
+                ActiveUsers                         = ($_.Group | Measure-Object ActiveUsers -Sum).Sum
+                InactiveUsers                       = ($_.Group | Measure-Object InactiveUsers -Sum).Sum
+                NeverLoggedInUsers                  = ($_.Group | Measure-Object NeverLoggedInUsers -Sum).Sum
+                ServiceAccountsManaged              = ($_.Group | Measure-Object ServiceAccountsManaged -Sum).Sum
+                ServiceAccountsGroupManaged         = ($_.Group | Measure-Object ServiceAccountsGroupManaged -Sum).Sum
+                ServiceAccountsPasswordNeverExpires = ($_.Group | Measure-Object ServiceAccountsPasswordNeverExpires -Sum).Sum
+                ServiceAccountsPatternMatched       = ($_.Group | Measure-Object ServiceAccountsPatternMatched -Sum).Sum
+                LicensedIdentities                  = ($_.Group | Measure-Object LicensedIdentities -Sum).Sum
+            }
+        }
+
+    # Build a grand-total row
+    $totals = [ordered]@{ Domain = 'TOTAL' }
+    foreach ($col in $rows | Get-Member -MemberType NoteProperty | Select-Object -Expand Name | Where-Object { $_ -ne 'Domain' }) {
+        $totals[$col] = ($rows | Measure-Object -Property $col -Sum).Sum
+    }
+
+    Write-Log "Successfully aggregated $($rows.Count) domain(s)."
+    return @($rows) + [PSCustomObject]$totals
+}
+
+#==================================================================================================
+# 5. EXPORTERS (CSV + HTML)
+#==================================================================================================
+function Export-CsvReport {
+    param(
+        [Parameter(Mandatory)]
+        [string]   $FileName,
+
+        [Parameter(Mandatory)]
+        [object[]] $Data,
+
+        [Parameter(Mandatory)]
+        [PSCustomObject] $Columns
+    )
+
+    $fullPath = Join-Path -Path $outputPath -ChildPath $FileName
+    $calculatedProperties = @()
+
+    try {
+        foreach ($name in $Columns.PSObject.Properties.Name) {
+            $header = $Columns."$name"
+            $calculatedProperties += @{
+                Name       = $header
+                Expression = [scriptblock]::Create("`$_.`"$name`"")
+            }
+        }
+
+        $Data | Select-Object -Property $calculatedProperties | Export-Csv -Path $fullPath -NoTypeInformation -Force
+        Write-Log "Successfully exported CSV report to $fullPath"
+    }
+    catch {
+        Write-Log "Could not export to CSV file $fullPath. Error: $_" "ERROR"
+    }
+}
+
+function Export-HtmlReport {
+    param(
+        [Parameter(Mandatory)]
+        [string]   $FileName,
+
+        [Parameter(Mandatory)]
+        [string]   $Title,
+
+        [Parameter(Mandatory)]
+        [object[]] $Data,
+
+        [Parameter(Mandatory)]
+        [PSCustomObject] $Columns,
+
+        [Parameter()]
+        [string] $MiddleReportTitle,
+
+        [Parameter()]
+        [object[]] $MiddleReportData,
+
+        [Parameter()]
+        [PSCustomObject] $MiddleReportColumns,
+
+        [Parameter()]
+        [string] $SecondReportTitle,
+
+        [Parameter()]
+        [object[]] $SecondReportData,
+
+        [Parameter()]
+        [PSCustomObject] $SecondReportColumns,
+
+        [Parameter(Mandatory)]
+        [string] $OutputPath
+    )
+
+    $fullPath = Join-Path -Path $OutputPath -ChildPath $FileName
+
+    try {
+        function New-HtmlTable {
+            param(
+                [Parameter(Mandatory)]
+                [string] $TableTitle,
+
+                [Parameter(Mandatory)]
+                [object[]] $TableData,
+
+                [Parameter(Mandatory)]
+                [PSCustomObject] $TableColumns
+            )
+           $svgContent = @"
+<svg xmlns="http://www.w3.org/2000/svg" height="72" width="72" viewBox="-8 -35000 278050 403334" shape-rendering="geometricPrecision" text-rendering="geometricPrecision" image-rendering="optimizeQuality" fill-rule="evenodd" clip-rule="evenodd">
+    <path fill="#ea3e23" d="M278050 305556l-29-16V28627L178807 0 448 66971l-448 87 22 200227 60865-23821V80555l117920-28193-17 239519L122 267285l178668 65976v73l99231-27462v-316z"/>
+</svg>
+"@
+
+            $html = "<div class='table-header'>"
+            $html += "<div class='table-header-logo'>$svgContent</div>"
+            $html += "<h2>$TableTitle</h2>"
+            $html += "</div>"
+            $html += "<div class='table-scroll'><table>"
+
+            $html += '<thead><tr>'
+            foreach ($header in $TableColumns.PSObject.Properties.Value) {
+                $html += "<th>$header</th>"
+            }
+            $html += '</tr></thead>'
+            $html += '<tbody>'
+
+            foreach ($row in $TableData) {
+                $isTotalRow = ($row.Domain -eq 'TOTAL')
+
+                $rowClass = ""
+                if ($isTotalRow) {
+                    $rowClass = ' class="total"'
+                }
+                $html += "<tr$rowClass>"
+
+                foreach ($colName in $TableColumns.PSObject.Properties.Name) {
+                    $value = $row."$colName"
+                    $html += "<td>$value</td>"
+                }
+                $html += '</tr>'
+            }
+
+            $html += '</tbody></table></div>'
+            return $html
+        }
+
+        $base64DataUri = "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIwIiBoZWlnaHQ9IjM4IiB2aWV3Qm94PSIwIDAgMTIwIDM4IiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTk1LjczMzMgMTIuNjkyMkM5NC4zMzE1IDEyLjY5MjIgOTMuNjk5NCAxMy4wOTcxIDkyLjQwMTggMTQuNzE3VjE0LjAxNzZDOTIuNDAxOCAxMy4xNzA2IDkyLjI5NjQgMTMuMDYwNiA5MS40ODk3IDEzLjA2MDZIOTAuODI0MkM5MC4wMTc2IDEzLjA2MDYgODkuOTEyMSAxMy4xNzA2IDg5LjkxMjEgMTQuMDE3NlYyNy4zNzc3Qzg5LjkxMjEgMjguMjI0NyA5MC4wMTc2IDI4LjMzNDcgOTAuODI0MiAyOC4zMzQ3SDkxLjQ4OTdDOTIuMjk2NCAyOC4zMzQ3IDkyLjQwMTggMjguMjI0NyA5Mi40MDE4IDI3LjM3NzdWMjAuMjc0MkM5Mi40MDE4IDE4LjQzMzggOTIuNTc3NiAxNy4zMzAzIDkyLjk2MyAxNi41OTQzQzkzLjQ5NTggMTUuNTc4IDk0LjY1NTggMTUuMDY4NyA5NS43Mjg1IDE1LjIyNTlDOTUuOTc4OCAxNS4yNjE5IDk2LjIgMTUuMzUwNCA5Ni40MzgyIDE1LjQzNDVDOTYuNTI2NyAxNS40NjUzIDk2LjYyODUgMTUuNDg4NiA5Ni43MTY0IDE1LjQ0ODVDOTYuODA2MSAxNS40MDcyIDk2Ljg3NjQgMTUuMzMyOCA5Ni45MzUyIDE1LjI1MjdDOTcuMDc3NiAxNS4wNjEyIDk3LjE2OTcgMTQuODMwMSA5Ny4yNzgyIDE0LjYxNjZDOTcuMzQ3MyAxNC40NzkzIDk3LjQxNjQgMTQuMzQyIDk3LjQ4NjcgMTQuMjAxMUM5Ny42Mjg1IDEzLjkwNjYgOTcuNzMzMyAxMy42ODYxIDk3LjczMzMgMTMuNTc2Qzk3Ljc2NzMgMTMuMDk3MSA5Ni44MjEyIDEyLjY5MjIgOTUuNzMzMyAxMi42OTIyWiIgZmlsbD0iIzA3MEY1MiIvPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTUxLjQxNzIgMTIuNjkyMkM1MC4wMTUyIDEyLjY5MjIgNDkuMzgzMSAxMy4wOTcxIDQ4LjA4NTggMTQuNzE3VjE0LjAxNzZDNDguMDg1OCAxMy4xNzA2IDQ3Ljk4MDYgMTMuMDYwNiA0Ny4xNzM2IDEzLjA2MDZINDYuNTA3NUM0NS43MDA2IDEzLjA2MDYgNDUuNTk1NyAxMy4xNzA2IDQ1LjU5NTcgMTQuMDE3NlYyNy4zNzc3QzQ1LjU5NTcgMjguMjI0NyA0NS43MDA2IDI4LjMzNDcgNDYuNTA3NSAyOC4zMzQ3SDQ3LjE3MzZDNDcuOTgwNiAyOC4zMzQ3IDQ4LjA4NTggMjguMjI0NyA0OC4wODU4IDI3LjM3NzdWMjAuMjc0MkM0OC4wODU4IDE4LjQzMzggNDguMjYwNyAxNy4zMzAzIDQ4LjY0NjYgMTYuNTk0M0M0OS4xNzg4IDE1LjU3OCA1MC4zMzkzIDE1LjA2ODcgNTEuNDExOCAxNS4yMjU5QzUxLjY2MTggMTUuMjYxOSA1MS44ODM2IDE1LjM1MDQgNTIuMTIxNSAxNS40MzQ1QzUyLjIwOTUgMTUuNDY1MyA1Mi4zMTE1IDE1LjQ4ODYgNTIuMzk5NSAxNS40NDg1QzUyLjQ4ODkgMTUuNDA3MiA1Mi41NTk4IDE1LjMzMjggNTIuNjE4NSAxNS4yNTI3QzUyLjc2MSAxNS4wNjEyIDUyLjg1MzMgMTQuODMwMSA1Mi45NjEyIDE0LjYxNjZDNTMuMDMwMyAxNC40NzkzIDUzLjA5OTkgMTQuMzQyIDUzLjE3MDQgMTQuMjAxMUM1My4zMTEzIDEzLjkwNjYgNTMuNDE2MiAxMy42ODYxIDUzLjQxNjIgMTMuNTc2QzUzLjQ1MTQgMTMuMDk3MSA1Mi41MDQ0IDEyLjY5MjIgNTEuNDE3MiAxMi42OTIyWiIgZmlsbD0iIzA3MEY1MiIvPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTU4LjYzMDIgMjEuOTY2OUM1OC42MzAyIDIzLjQwMTkgNTguNzcwNyAyNC4xNzU3IDU5LjA4NTcgMjQuODM4MkM1OS41NzY0IDI1Ljc5NTUgNjAuNjYzOCAyNi4zODQxIDYxLjkyNjMgMjYuMzg0MUM2My4xNTM1IDI2LjM4NDEgNjQuMjQwOCAyNS43OTU1IDY0LjczMjMgMjQuODM4MkM2NS4wNDc1IDI0LjE3NTcgNjUuMTg4MSAyMy40MDE5IDY1LjE4ODEgMjEuOTY2OVYxNC4wMTczQzY1LjE4ODEgMTMuMTcwNCA2NS4yOTM1IDEzLjA2MDQgNjYuMTAwMiAxMy4wNjA0SDY2Ljc2NjNDNjcuNTcyOSAxMy4wNjA0IDY3LjY3NzggMTMuMTcwNCA2Ny42Nzc4IDE0LjAxNzNWMjIuMjYxNEM2Ny42Nzc4IDI0LjUwNzIgNjcuMzI3NSAyNS43MjE2IDY2LjM0NTcgMjYuODYyMUM2NS4yOTM1IDI4LjExMzkgNjMuNzE0OCAyOC43NzU1IDYxLjkyNjMgMjguNzc1NUM2MC4xMDI0IDI4Ljc3NTUgNTguNTI1NCAyOC4xMTM5IDU3LjQ3MyAyNi44NjIxQzU2LjQ5MDcgMjUuNzIxNiA1Ni4xNDAxIDI0LjUwNzIgNTYuMTQwMSAyMi4yNjE0VjE0LjAxNzNDNTYuMTQwMSAxMy4xNzA0IDU2LjI0NSAxMy4wNjA0IDU3LjA1MiAxMy4wNjA0SDU3LjcxOEM1OC41MjU0IDEzLjA2MDQgNTguNjMwMiAxMy4xNzA0IDU4LjYzMDIgMTQuMDE3M1YyMS45NjY5WiIgZmlsbD0iIzA3MEY1MiIvPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTc0LjA3NiAyMC42NzkxQzc0LjA3NiAyNC4wNjU4IDc2LjA3NiAyNi4zODQ3IDc4Ljk1MTggMjYuMzg0N0M4MS43MjIxIDI2LjM4NDcgODMuNzIwOSAyMy45NTQ5IDgzLjcyMDkgMjAuNjA1NkM4My43MjA5IDE3LjUxNDIgODEuNjUxOCAxNS4xMjE0IDc4LjkxNjYgMTUuMTIxNEM3Ni4wNzYgMTUuMTIxNCA3NC4wNzYgMTcuNDAzNyA3NC4wNzYgMjAuNjc5MVpNNzQuMjUyNCAxNS4yMzI0Qzc1LjY4OTQgMTMuNTAyNCA3Ny4yMzMgMTIuNzI5MSA3OS4zMzcyIDEyLjcyOTFDODMuMzM0OCAxMi43MjkxIDg2LjI4MDkgMTYuMDc4NCA4Ni4yODA5IDIwLjY3OTFDODYuMjgwOSAyNS4zNTM3IDgzLjI5OTcgMjguNzc2MSA3OS4yNjY5IDI4Ljc3NjFDNzcuMjMzIDI4Ljc3NjEgNzUuNjE5NyAyNy45NjYyIDc0LjI1MjQgMjYuMjM3NlYyNy4zNzc2Qzc0LjI1MjQgMjguMjI0NiA3NC4xNDY5IDI4LjMzNDYgNzMuMzM5NyAyOC4zMzQ2SDcyLjY3NDJDNzEuODY2OSAyOC4zMzQ2IDcxLjc2MTUgMjguMjI0NiA3MS43NjE1IDI3LjM3NzZWMi40NTk3OUM3MS43NjE1IDEuNjEzNzcgNzEuODY2OSAxLjUwMzcyIDcyLjY3NDIgMS41MDM3Mkg3My4zMzk3Qzc0LjE0NjkgMS41MDM3MiA3NC4yNTI0IDEuNjEzNzcgNzQuMjUyNCAyLjQ1OTc5VjE1LjIzMjRaIiBmaWxsPSIjMDcwRjUyIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMTAzLjQ3MyAyNy4zNzc3QzEwMy40NzMgMjguMjI0NyAxMDMuMzY3IDI4LjMzNDcgMTAyLjU2MSAyOC4zMzQ3SDEwMS44OTRDMTAxLjA4NyAyOC4zMzQ3IDEwMC45ODMgMjguMjI0NyAxMDAuOTgzIDI3LjM3NzdWMTQuMDE3MUMxMDAuOTgzIDEzLjE3MTEgMTAxLjA4NyAxMy4wNjAxIDEwMS44OTQgMTMuMDYwMUgxMDIuNTYxQzEwMy4zNjcgMTMuMDYwMSAxMDMuNDczIDEzLjE3MTEgMTAzLjQ3MyAxNC4wMTcxVjI3LjM3NzdaTTEwNC4wMzQgNy4yODQwNkMxMDQuMDM0IDguMzE2MSAxMDMuMjI3IDkuMTYzMDUgMTAyLjI0NSA5LjE2MzA1QzEwMS4yNjMgOS4xNjMwNSAxMDAuNDU3IDguMzE2MSAxMDAuNDU3IDcuMjQ3MDdDMTAwLjQ1NyA2LjI1MjQ4IDEwMS4yNjMgNS40MDUwOSAxMDIuMjQ1IDUuNDA1MDlDMTAzLjIyNyA1LjQwNTA5IDEwNC4wMzQgNi4yNTI0OCAxMDQuMDM0IDcuMjg0MDZaIiBmaWxsPSIjMDcwRjUyIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMTE1LjQ0OCAxMy41MDI1QzExNS44NjggMTMuMDYwNSAxMTUuODY4IDEzLjA2MDUgMTE2LjQ2NSAxMy4wNjA1SDExNy41NTJDMTE4LjE4MyAxMy4wNjA1IDExOC40MjkgMTMuMjQ0OSAxMTguNDI5IDEzLjY0OTVDMTE4LjQyOSAxMy43OTY1IDExOC4yODggMTQuMDE3NSAxMTguMDA4IDE0LjMxMkwxMTIuOTkyIDE5LjU3NTZMMTE5LjM0IDI3LjA4MzZDMTE5LjU4NiAyNy40MTQ3IDExOS43MjcgMjcuNjM2IDExOS43MjcgMjcuNzgzMUMxMTkuNzI3IDI4LjE1MTEgMTE5LjQ0NiAyOC4zMzUxIDExOC44MTQgMjguMzM1MUgxMTcuNzI3QzExNy4wOTYgMjguMzM1MSAxMTcuMDk2IDI4LjMzNTEgMTE2LjcxIDI3Ljg1NjZMMTExLjIzOSAyMS4zNzg1TDExMC42MDcgMjIuMDQxVjI3LjM3ODFDMTEwLjYwNyAyOC4yMjQ2IDExMC41MDIgMjguMzM1MSAxMDkuNjk2IDI4LjMzNTFIMTA5LjAzQzEwOC4yMjMgMjguMzM1MSAxMDguMTE4IDI4LjIyNDYgMTA4LjExOCAyNy4zNzgxVjIuNDYwMjJDMTA4LjExOCAxLjYxMzc2IDEwOC4yMjMgMS41MDM3MiAxMDkuMDMgMS41MDM3MkgxMDkuNjk2QzExMC41MDIgMS41MDM3MiAxMTAuNjA3IDEuNjEzNzYgMTEwLjYwNyAyLjQ2MDIyVjE4LjY5MjFMMTE1LjQ0OCAxMy41MDI1WiIgZmlsbD0iIzA3MEY1MiIvPgo8L3N2Zz4K"
+        $logoHtml = "<img src='$base64DataUri' class='header-svg' alt='Rubrik Logo' />"
+
+        $css = @"
+<style>
+    body {
+        font-family: Arial, sans-serif;
+        background-color: #f0f2f5;
+        color: #333;
+        margin: 0;
+        padding: 0;
+    }
+    .report-container {
+        width: 98%;
+        max-width: none;
+        margin: 20px auto;
+        padding: 20px;
+        background-color: #fff;
+        border-radius: 8px;
+        box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+        box-sizing: border-box;
+    }
+    .header {
+        background-color: #0d47a1;
+        color: #fff;
+        padding: 20px;
+        border-top-left-radius: 8px;
+        border-top-right-radius: 8px;
+        display: flex;
+        align-items: center;
+        justify-content: flex-start;
+    }
+    .table-header {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+    border-bottom: 2px solid #e0e6ed;
+    padding-bottom: 10px;
+    margin-bottom: 20px;
+    }
+    .header h1 {
+        margin: 0;
+        font-size: 24px;
+        margin-left: 20px;
+    }
+    .header-logo {
+        height: 40px;
+    }
+    .header svg {
+        height: 45px;
+        width: auto;
+    }
+    h2 {
+        color: #0d47a1;
+        font-size: 20px;
+        padding-bottom: 10px;
+        margin-top: 30px;
+    }
+    .table-scroll {
+        width: 100%;
+        margin-bottom: 20px;
+    }
+    table {
+        width: 100%;
+        border-collapse: collapse;
+        table-layout: auto;
+    }
+    th, td {
+        padding: 12px;
+        text-align: center;
+        border: 1px solid #ddd;
+    }
+    td:first-child, th:first-child {
+        white-space: normal;
+    }
+    thead th {
+        background-color: #2c3e50;
+        color: white;
+        font-weight: bold;
+        text-transform: uppercase;
+        font-size: 13px;
+        border: 1px solid #2c3e50;
+    }
+    tbody tr:nth-child(odd) {
+        background-color: #f9f9f9;
+    }
+    tbody tr:nth-child(even) {
+        background-color: #fff;
+    }
+    tbody tr:hover {
+        background-color: #e8f4fd;
+    }
+    tr.total {
+        font-weight: bold;
+        background-color: #2c3e50 !important;
+        color: #fff;
+    }
+    .footer {
+        text-align: center;
+        padding: 15px;
+        font-size: 12px;
+        color: #888;
+        border-top: 1px solid #ddd;
+        margin-top: 20px;
+    }
+</style>
+"@
+
+        $htmlBody = @"
+<html>
+<head>
+    <title>AD Report</title>
+    $css
+</head>
+<body>
+    <div class="report-container">
+        <div class="header">
+            $logoHtml
+            <h1>AD Report</h1>
+        </div>
+        <br>
+"@
+
+        # Add the first table
+        $htmlBody += New-HtmlTable -TableTitle $Title -TableData $Data -TableColumns $Columns
+
+        # If a middle report (licensing) is provided, add it
+        if ($MiddleReportData) {
+            $htmlBody += "<br>"
+            $htmlBody += New-HtmlTable -TableTitle $MiddleReportTitle -TableData $MiddleReportData -TableColumns $MiddleReportColumns
+        }
+
+        # If a second report is provided, add it
+        if ($SecondReportData) {
+            $htmlBody += "<br>"
+            $htmlBody += New-HtmlTable -TableTitle $SecondReportTitle -TableData $SecondReportData -TableColumns $SecondReportColumns
+        }
+
+        $htmlBody += @"
+        <div class="footer">
+            Generated on $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')<br/>
+            Command: $($script:commandLine)
+        </div>
+    </div>
+</body>
+</html>
+"@
+
+        $htmlBody | Out-File -FilePath $fullPath -Encoding UTF8
+        Write-Log "Successfully exported HTML report to $fullPath"
+    }
+    catch {
+        Write-Log "Could not export to HTML file $fullPath. Error: $_" "ERROR"
+    }
+}
+
+#==================================================================================================
+# 6. MAIN
+#==================================================================================================
+
+#— 1) Discover domains
 $logonThreshold = (Get-Date).AddDays(-180)
-$summary = @()
-
 $domainsToAudit = if ($SpecificDomains) {
     $SpecificDomains
 } else {
     [System.DirectoryServices.ActiveDirectory.Forest]::GetCurrentForest().Domains | ForEach-Object { $_.Name }
 }
 
-foreach ($domain in $domainsToAudit) {
-    Write-Log "Auditing domain: $domain" -ForegroundColor Cyan
+#— 2) Build per-OU dataset
+Write-Log "Building per-OU dataset..."
+$byOU = Get-ByOUData `
+    -DomainsToAudit $domainsToAudit `
+    -ServicePattern $UserServiceAccountNamesLike `
+    -ExcludeOUs $ExcludeOUs `
+    -LogonThreshold $logonThreshold
 
-    try {
-        # Preload reference data
-        $MSASet = Get-ADServiceAccount -Server $domain -Filter { ObjectClass -eq 'msDS-ManagedServiceAccount' } |
-                  Select-Object -ExpandProperty SamAccountName
-        $GMSASet = Get-ADServiceAccount -Server $domain -Filter { ObjectClass -eq 'msDS-GroupManagedServiceAccount' } |
-                   Select-Object -ExpandProperty SamAccountName
-        $NoExpireSet = Get-ADUser -Server $domain -Filter { PasswordNeverExpires -eq $true -and Enabled -eq $true } |
-                       Select-Object -ExpandProperty SamAccountName
+# Filter out the TOTAL row before passing to Get-ByDomainData
+$ouDataInput = $byOU | Select-Object -SkipLast 1
 
-        # 🔍 Get pattern-matched service accounts
-        $PatternMatches = Get-UsersAsServiceAccount -NamePatterns $UserServiceAccountNamesLike -Domain $domain
-        $PatternSet = $PatternMatches.SamAccountName | Sort-Object -Unique
+#— 3) Aggregate by domain
+Write-Log "Building aggregated report by Domain..."
+$byDomain = Get-ByDomainData -OUData $ouDataInput
 
-        # 🧾 Get users
-        $userAccounts = Get-ADUser -Server $domain -Filter { Enabled -eq $true } `
-            -Properties SamAccountName, DistinguishedName, LastLogonTimestamp
+#— 3b) Licensing data
+Write-Log "Preparing Rubrik licensing data..."
+$licensingData = $byDomain | Select-Object Domain, LicensedIdentities
 
-        $msaObjects  = @(Get-ADServiceAccount -Server $domain -Filter { ObjectClass -eq 'msDS-ManagedServiceAccount' })
-        $gmsaObjects = @(Get-ADServiceAccount -Server $domain -Filter { ObjectClass -eq 'msDS-GroupManagedServiceAccount' })
+#— 4) Report headers
+$ouCols        = Get-ReportHeaders -Type ByOU
+$domainCols    = Get-ReportHeaders -Type ByDomain
+$licensingCols = Get-ReportHeaders -Type Licensing
 
-        $serviceAccounts = $msaObjects + $gmsaObjects | ForEach-Object {
-            [PSCustomObject]@{
-                SamAccountName     = $_.SamAccountName
-                DistinguishedName  = $_.DistinguishedName
-                LastLogonTimestamp = $_.LastLogonTimestamp
-            }
-        }
+#— 5) Export CSV & HTML
+if ($Mode -eq 'Full') {
+    Write-Log "Exporting Full reports in CSV and HTML format..."
 
-        $users = $userAccounts + $serviceAccounts
-
-        foreach ($user in $users) {
-            $sam = $user.SamAccountName
-            $ou  = Get-OUFromDN $user.DistinguishedName
-
-            $entry = $summary | Where-Object { $_.Domain -eq $domain -and $_.OU -eq $ou }
-            if (-not $entry) {
-                $entry = [PSCustomObject]@{
-                    Domain                              = $domain
-                    OU                                  = $ou
-                    TotalUsers                          = 0
-                    ActiveUsers                         = 0
-                    InactiveUsers                       = 0
-                    NeverLoggedInUsers                  = 0
-                    ServiceAccountsManaged              = 0
-                    ServiceAccountsGroupManaged         = 0
-                    ServiceAccountsPasswordNeverExpires = 0
-                    ServiceAccountsPatternMatched       = 0
-                }
-                $summary += $entry
-            }
-
-            $entry.TotalUsers++
-            if ($user.LastLogonTimestamp) {
-                if ($user.LastLogonTimestamp -ge $logonThreshold.ToFileTime()) {
-                    $entry.ActiveUsers++
-                } else {
-                    $entry.InactiveUsers++
-                }
-            } else {
-                $entry.NeverLoggedInUsers++
-            }
-
-            if (Test-ManagedServiceAccount      $sam $MSASet)      { $entry.ServiceAccountsManaged++ }
-            elseif (Test-GroupManagedServiceAccount $sam $GMSASet)     { $entry.ServiceAccountsGroupManaged++ }
-            if (Test-NonExpiringUser            $sam $NoExpireSet) { $entry.ServiceAccountsPasswordNeverExpires++ }
-            if (Test-PatternMatchedUser         $sam $PatternSet)  { $entry.ServiceAccountsPatternMatched++ }
-        }
-    } catch {
-        Write-Warning "Failed processing domain $domain : $_"
-    }
+    Export-CsvReport -FileName "Full_ByOU_$timestamp.csv"      -Data $byOU          -Columns $ouCols
+    Export-CsvReport -FileName "Full_ByDomain_$timestamp.csv"  -Data $byDomain      -Columns $domainCols
+    Export-CsvReport -FileName "Full_Licensing_$timestamp.csv" -Data $licensingData  -Columns $licensingCols
+    Export-HtmlReport -FileName "Full_Report_$timestamp.html" `
+                   -Title 'Domain Summary' `
+                   -Data  $byDomain `
+                   -Columns $domainCols `
+                   -MiddleReportTitle 'Rubrik Licensing' `
+                   -MiddleReportData $licensingData `
+                   -MiddleReportColumns $licensingCols `
+                   -SecondReportTitle 'OU Details' `
+                   -SecondReportData $byOU `
+                   -SecondReportColumns $ouCols `
+                   -OutputPath $OutputPath
 }
-# =====================
-# Report Output
-# =====================
+else {
+    Write-Log "Exporting Summary reports in CSV and HTML format..."
 
-# Create unique filename with timestamp
-$timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
-$fileName = "UserAudit_${Mode}_$timestamp.csv"
-$fullExportPath = Join-Path -Path $outputPath -ChildPath $fileName
-
-switch ($Mode) {
-
-    "UserPerOU" {
-        Write-Log "OU Summary Report" -ForegroundColor Green
-        $summary | Sort-Object Domain, OU | Format-Table -AutoSize
-        $summary | Sort-Object Domain, OU | Export-Csv -Path $fullExportPath -NoTypeInformation -Encoding UTF8
-    }
-    "Summary" {
-        $summaryGrouped = $summary |
-            Group-Object Domain |
-            ForEach-Object {
-                [PSCustomObject]@{
-                    Domain                              = $_.Name
-                    TotalUsers                          = ($_.Group | Measure-Object TotalUsers -Sum).Sum
-                    ActiveUsers                         = ($_.Group | Measure-Object ActiveUsers -Sum).Sum
-                    InactiveUsers                       = ($_.Group | Measure-Object InactiveUsers -Sum).Sum
-                    NeverLoggedInUsers                  = ($_.Group | Measure-Object NeverLoggedInUsers -Sum).Sum
-                    ServiceAccountsManaged              = ($_.Group | Measure-Object ServiceAccountsManaged -Sum).Sum
-                    ServiceAccountsGroupManaged         = ($_.Group | Measure-Object ServiceAccountsGroupManaged -Sum).Sum
-                    ServiceAccountsPasswordNeverExpires = ($_.Group | Measure-Object ServiceAccountsPasswordNeverExpires -Sum).Sum
-                    ServiceAccountsPatternMatched       = ($_.Group | Measure-Object ServiceAccountsPatternMatched -Sum).Sum
-                }
-            }
-
-        Write-Log "Domain Summary Report" -ForegroundColor Green
-        $summaryGrouped | Sort-Object Domain | Format-Table -AutoSize
-        $summaryGrouped | Export-Csv -Path $fullExportPath -NoTypeInformation -Encoding UTF8
-    }
+    Export-CsvReport -FileName "Summary_ByDomain_$timestamp.csv"  -Data $byDomain      -Columns $domainCols
+    Export-CsvReport -FileName "Summary_Licensing_$timestamp.csv" -Data $licensingData  -Columns $licensingCols
+    Export-HtmlReport -FileName "Summary_Report_$timestamp.html" -Title 'Domain Summary' `
+                   -Data $byDomain -Columns $domainCols `
+                   -MiddleReportTitle 'Rubrik Licensing' `
+                   -MiddleReportData $licensingData `
+                   -MiddleReportColumns $licensingCols `
+                   -OutputPath $OutputPath
 }
 
-Write-Log "Results have been saved into $fullExportPath. Please send all the files within the directory to your Rubrik Sales representative." -ForegroundColor Green
+Write-Log "AD reports generation completed."
 
 # Reset Culture settings back to original value
 [System.Threading.Thread]::CurrentThread.CurrentCulture = $OriginalCulture

--- a/IDENTITY/Get-AdHumanIdentity.ps1
+++ b/IDENTITY/Get-AdHumanIdentity.ps1
@@ -90,13 +90,12 @@
     - Save the reports in CSV and HTML format in the .\ADReports directory.
 
 .NOTES
+    Author: Aymeric Jaouen
+
     - **Prerequisites**: The computer running this script must have the Active Directory module for PowerShell installed. This is part of the Remote Server Administration Tools (RSAT).
     - **Permissions**: The user account running this script must have read permissions for user and service account objects in the target Active Directory domains.
     - **Execution Policy**: You may need to adjust the PowerShell execution policy to run this script. You can do this by running "Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope Process".
     - **Culture Settings**: The script temporarily sets the culture to 'en-US' to ensure that dates and times are parsed correctly. This change is reverted at the end of the script.
-
-.AUTOR
-    Aymeric Jaouen
 #>
 
 
@@ -105,7 +104,8 @@ param (
     [string[]]$SpecificDomains,
     [string[]]$ExcludeOUs = @(),
     [ValidateSet("Full", "Summary")]
-    [string]$Mode = "Full"
+    [string]$Mode = "Full",
+    [int]$DaysInactive = 180
 )
 
 # === Logging Setup ===
@@ -117,11 +117,12 @@ $logPath = Join-Path $outputPath "AD_Audit_$timestamp.log"
 function Write-Log {
     param (
         [string]$Message,
-        [string]$Level = "INFO"
+        [string]$Level = "INFO",
+        [System.ConsoleColor]$Color = "White"
     )
     $formatted = "[{0}] [{1}] {2}" -f (Get-Date -Format "yyyy-MM-dd HH:mm:ss"), $Level, $Message
     Add-Content -Path $logPath -Value $formatted
-    Write-Host $Message
+    Write-Host $Message -ForegroundColor $Color
 }
 
 # === Log the command that started the script ===
@@ -142,11 +143,11 @@ try {
         $commandString += " -$paramName $formattedValue"
     }
     $script:commandLine = $commandString
-    Write-Log "Script started with command: $commandString" "INFO"
+    Write-Log "Script started with command: $commandString" "INFO" "Magenta"
 }
 catch {
     $script:commandLine = "N/A"
-    Write-Log "Could not log the command line. Error: $_" "WARNING"
+    Write-Log "Could not log the command line. Error: $_" "WARNING" "Yellow"
 }
 
 function Initialize-Prerequisites {
@@ -154,18 +155,18 @@ function Initialize-Prerequisites {
     $moduleName = "ActiveDirectory"
 
     if ($PSVersionTable.PSVersion -lt $requiredPSVersion) {
-        Write-Log "PowerShell $requiredPSVersion or higher is required. Current version: $($PSVersionTable.PSVersion)"
+        Write-Log "PowerShell $requiredPSVersion or higher is required. Current version: $($PSVersionTable.PSVersion)" "ERROR" "Red"
         exit
     }
 
     try {
         if (-not (Get-Module -ListAvailable -Name $moduleName)) {
-            Write-Log "Required module '$moduleName' not found. Please install RSAT: Active Directory Tools."
+            Write-Log "Required module '$moduleName' not found. Please install RSAT: Active Directory Tools." "ERROR" "Red"
             exit
         }
         Import-Module $moduleName -ErrorAction Stop
     } catch {
-        Write-Log "Failed to import '$moduleName'. Ensure it's installed and accessible. $_"
+        Write-Log "Failed to import '$moduleName'. Ensure it's installed and accessible. $_" "ERROR" "Red"
         exit
     }
 
@@ -176,7 +177,7 @@ function Initialize-Prerequisites {
     [System.Threading.Thread]::CurrentThread.CurrentCulture = 'en-US'
     [System.Threading.Thread]::CurrentThread.CurrentUICulture = 'en-US'
 
-    Write-Log "Prerequisites validated. Environment initialized."
+    Write-Log "Prerequisites validated. Environment initialized." "INFO" "Green"
 }
 
 Initialize-Prerequisites
@@ -241,26 +242,6 @@ function Get-OUFromDN {
     $parts[1..($parts.Count - 1)] -join ','
 }
 
-function Test-ManagedServiceAccount {
-    param ([string]$SamAccountName, [string[]]$MSASet)
-    return $MSASet -contains $SamAccountName
-}
-
-function Test-GroupManagedServiceAccount {
-    param ([string]$SamAccountName, [string[]]$GMSASet)
-    return $GMSASet -contains $SamAccountName
-}
-
-function Test-NonExpiringUser {
-    param ([string]$SamAccountName, [string[]]$NoExpireSet)
-    return $NoExpireSet -contains $SamAccountName
-}
-
-function Test-PatternMatchedUser {
-    param ([string]$SamAccountName, [string[]]$PatternSet)
-    return $PatternSet -contains $SamAccountName
-}
-
 function Get-UsersAsServiceAccount {
     param (
         [string[]]$NamePatterns,
@@ -273,9 +254,10 @@ function Get-UsersAsServiceAccount {
 
     $subs = @()
     foreach ($pattern in $NamePatterns) {
-        Write-Log "[$Domain] Searching for users like '$pattern'..."
+        $safePattern = $pattern.Trim().Replace("'", "''")
+        Write-Log "[$Domain] Searching for users like '$safePattern'..." "INFO" "Cyan"
         try {
-            $usersFound = Get-ADUser -Server $Domain -Filter "Name -like '$($pattern.Trim())'" `
+            $usersFound = Get-ADUser -Server $Domain -Filter "Name -like '$safePattern'" `
                 -Properties Name, SamAccountName, DistinguishedName, Enabled, LastLogonTimestamp, PasswordNeverExpires, ServicePrincipalName |
                 Select-Object Name, SamAccountName, DistinguishedName, Enabled,
                               @{Name="LastLogonDate";Expression={[DateTime]::FromFileTime($_.LastLogonTimestamp)}},
@@ -284,7 +266,7 @@ function Get-UsersAsServiceAccount {
 
             $subs += $usersFound
         } catch {
-            Write-Warning "[$Domain] Error searching pattern '$pattern': $_"
+            Write-Log "[$Domain] Error searching pattern '$safePattern': $_" "WARNING" "Yellow"
         }
     }
     return $subs
@@ -309,29 +291,31 @@ function Get-ByOUData {
         [datetime] $LogonThreshold
     )
 
-    $summary = @()
+    $summaryMap = @{}
 
     foreach ($domain in $DomainsToAudit) {
-        Write-Log "Auditing domain: $domain"
+        Write-Log "Auditing domain: $domain" "INFO" "Cyan"
 
         try {
-            $MSASet = Get-ADServiceAccount -Server $domain -Filter { ObjectClass -eq 'msDS-ManagedServiceAccount' } |
-                      Select-Object -ExpandProperty SamAccountName
-            $GMSASet = Get-ADServiceAccount -Server $domain -Filter { ObjectClass -eq 'msDS-GroupManagedServiceAccount' } |
-                       Select-Object -ExpandProperty SamAccountName
-            $NoExpireSet = Get-ADUser -Server $domain -Filter { PasswordNeverExpires -eq $true -and Enabled -eq $true } |
-                           Select-Object -ExpandProperty SamAccountName
+            $msaObjects  = @(Get-ADServiceAccount -Server $domain -Filter "ObjectClass -eq 'msDS-ManagedServiceAccount'" -Properties SamAccountName, DistinguishedName, LastLogonTimestamp)
+            $gmsaObjects = @(Get-ADServiceAccount -Server $domain -Filter "ObjectClass -eq 'msDS-GroupManagedServiceAccount'" -Properties SamAccountName, DistinguishedName, LastLogonTimestamp)
+
+            $msaNames     = @($msaObjects | Select-Object -ExpandProperty SamAccountName)
+            $gmsaNames    = @($gmsaObjects | Select-Object -ExpandProperty SamAccountName)
+            $noExpireNames = @(Get-ADUser -Server $domain -Filter "PasswordNeverExpires -eq `$true -and Enabled -eq `$true" | Select-Object -ExpandProperty SamAccountName)
+
+            $MSASet      = [System.Collections.Generic.HashSet[string]]::new([string[]]$msaNames, [System.StringComparer]::OrdinalIgnoreCase)
+            $GMSASet     = [System.Collections.Generic.HashSet[string]]::new([string[]]$gmsaNames, [System.StringComparer]::OrdinalIgnoreCase)
+            $NoExpireSet = [System.Collections.Generic.HashSet[string]]::new([string[]]$noExpireNames, [System.StringComparer]::OrdinalIgnoreCase)
 
             $PatternMatches = Get-UsersAsServiceAccount -NamePatterns $ServicePattern -Domain $domain
-            $PatternSet = $PatternMatches.SamAccountName | Sort-Object -Unique
+            $patternNames = @($PatternMatches | Select-Object -ExpandProperty SamAccountName)
+            $PatternSet = [System.Collections.Generic.HashSet[string]]::new([string[]]$patternNames, [System.StringComparer]::OrdinalIgnoreCase)
 
-            $userAccounts = Get-ADUser -Server $domain -Filter { Enabled -eq $true } `
+            $userAccounts = Get-ADUser -Server $domain -Filter "Enabled -eq `$true" `
                 -Properties SamAccountName, DistinguishedName, LastLogonTimestamp
 
-            $msaObjects  = @(Get-ADServiceAccount -Server $domain -Filter { ObjectClass -eq 'msDS-ManagedServiceAccount' })
-            $gmsaObjects = @(Get-ADServiceAccount -Server $domain -Filter { ObjectClass -eq 'msDS-GroupManagedServiceAccount' })
-
-            $serviceAccounts = $msaObjects + $gmsaObjects | ForEach-Object {
+            $serviceAccounts = ($msaObjects + $gmsaObjects) | ForEach-Object {
                 [PSCustomObject]@{
                     SamAccountName     = $_.SamAccountName
                     DistinguishedName  = $_.DistinguishedName
@@ -347,9 +331,9 @@ function Get-ByOUData {
 
                 if ($ExcludeOUs -contains $ou) { continue }
 
-                $entry = $summary | Where-Object { $_.Domain -eq $domain -and $_.OU -eq $ou }
-                if (-not $entry) {
-                    $entry = [PSCustomObject]@{
+                $key = "$domain|$ou"
+                if (-not $summaryMap.ContainsKey($key)) {
+                    $summaryMap[$key] = [PSCustomObject]@{
                         Domain                              = $domain
                         OU                                  = $ou
                         TotalUsers                          = 0
@@ -362,8 +346,8 @@ function Get-ByOUData {
                         ServiceAccountsPatternMatched       = 0
                         LicensedIdentities                  = 0
                     }
-                    $summary += $entry
                 }
+                $entry = $summaryMap[$key]
 
                 $entry.TotalUsers++
 
@@ -379,13 +363,13 @@ function Get-ByOUData {
                     $entry.NeverLoggedInUsers++
                 }
 
-                $isMSA     = Test-ManagedServiceAccount $sam $MSASet
-                $isGMSA    = Test-GroupManagedServiceAccount $sam $GMSASet
-                $isPattern = Test-PatternMatchedUser $sam $PatternSet
+                $isMSA     = $MSASet.Contains($sam)
+                $isGMSA    = $GMSASet.Contains($sam)
+                $isPattern = $PatternSet.Contains($sam)
 
                 if ($isMSA)      { $entry.ServiceAccountsManaged++ }
                 elseif ($isGMSA) { $entry.ServiceAccountsGroupManaged++ }
-                if (Test-NonExpiringUser $sam $NoExpireSet) { $entry.ServiceAccountsPasswordNeverExpires++ }
+                if ($NoExpireSet.Contains($sam)) { $entry.ServiceAccountsPasswordNeverExpires++ }
                 if ($isPattern)  { $entry.ServiceAccountsPatternMatched++ }
 
                 if ($isActive -and -not $isMSA -and -not $isGMSA -and -not $isPattern) {
@@ -393,11 +377,13 @@ function Get-ByOUData {
                 }
             }
 
-            Write-Log "Successfully processed domain '$domain'. Found $($users.Count) accounts."
+            Write-Log "Successfully processed domain '$domain'. Found $($users.Count) accounts." "INFO" "Green"
         } catch {
-            Write-Log "Failed processing domain $domain : $_" "ERROR"
+            Write-Log "Failed processing domain $domain : $_" "ERROR" "Red"
         }
     }
+
+    $summary = @($summaryMap.Values | Sort-Object Domain, OU)
 
     # Build a grand-total row
     $totals = [ordered]@{ Domain = 'TOTAL'; OU = '' }
@@ -405,7 +391,7 @@ function Get-ByOUData {
         $totals[$col] = ($summary | Measure-Object -Property $col -Sum).Sum
     }
 
-    Write-Log "Successfully built $($summary.Count) OU records across all domains."
+    Write-Log "Successfully built $($summary.Count) OU records across all domains." "INFO" "Green"
     return $summary + [PSCustomObject]$totals
 }
 
@@ -442,7 +428,7 @@ function Get-ByDomainData {
         $totals[$col] = ($rows | Measure-Object -Property $col -Sum).Sum
     }
 
-    Write-Log "Successfully aggregated $($rows.Count) domain(s)."
+    Write-Log "Successfully aggregated $($rows.Count) domain(s)." "INFO" "Green"
     return @($rows) + [PSCustomObject]$totals
 }
 
@@ -473,11 +459,11 @@ function Export-CsvReport {
             }
         }
 
-        $Data | Select-Object -Property $calculatedProperties | Export-Csv -Path $fullPath -NoTypeInformation -Force
-        Write-Log "Successfully exported CSV report to $fullPath"
+        $Data | Select-Object -Property $calculatedProperties | Export-Csv -Path $fullPath -NoTypeInformation -Encoding UTF8 -Force
+        Write-Log "Successfully exported CSV report to $fullPath" "INFO" "Green"
     }
     catch {
-        Write-Log "Could not export to CSV file $fullPath. Error: $_" "ERROR"
+        Write-Log "Could not export to CSV file $fullPath. Error: $_" "ERROR" "Red"
     }
 }
 
@@ -545,7 +531,8 @@ function Export-HtmlReport {
 
             $html += '<thead><tr>'
             foreach ($header in $TableColumns.PSObject.Properties.Value) {
-                $html += "<th>$header</th>"
+                $safeHeader = [System.Net.WebUtility]::HtmlEncode($header)
+                $html += "<th>$safeHeader</th>"
             }
             $html += '</tr></thead>'
             $html += '<tbody>'
@@ -560,7 +547,7 @@ function Export-HtmlReport {
                 $html += "<tr$rowClass>"
 
                 foreach ($colName in $TableColumns.PSObject.Properties.Name) {
-                    $value = $row."$colName"
+                    $value = [System.Net.WebUtility]::HtmlEncode("$($row."$colName")")
                     $html += "<td>$value</td>"
                 }
                 $html += '</tr>'
@@ -711,7 +698,7 @@ function Export-HtmlReport {
         $htmlBody += @"
         <div class="footer">
             Generated on $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')<br/>
-            Command: $($script:commandLine)
+            Command: $([System.Net.WebUtility]::HtmlEncode($script:commandLine))
         </div>
     </div>
 </body>
@@ -719,10 +706,10 @@ function Export-HtmlReport {
 "@
 
         $htmlBody | Out-File -FilePath $fullPath -Encoding UTF8
-        Write-Log "Successfully exported HTML report to $fullPath"
+        Write-Log "Successfully exported HTML report to $fullPath" "INFO" "Green"
     }
     catch {
-        Write-Log "Could not export to HTML file $fullPath. Error: $_" "ERROR"
+        Write-Log "Could not export to HTML file $fullPath. Error: $_" "ERROR" "Red"
     }
 }
 
@@ -730,16 +717,23 @@ function Export-HtmlReport {
 # 6. MAIN
 #==================================================================================================
 
+try {
+
 #— 1) Discover domains
-$logonThreshold = (Get-Date).AddDays(-180)
-$domainsToAudit = if ($SpecificDomains) {
-    $SpecificDomains
+$logonThreshold = (Get-Date).AddDays(-$DaysInactive)
+if ($SpecificDomains) {
+    $domainsToAudit = $SpecificDomains
 } else {
-    [System.DirectoryServices.ActiveDirectory.Forest]::GetCurrentForest().Domains | ForEach-Object { $_.Name }
+    try {
+        $domainsToAudit = [System.DirectoryServices.ActiveDirectory.Forest]::GetCurrentForest().Domains | ForEach-Object { $_.Name }
+    } catch {
+        Write-Log "Failed to discover AD forest. Ensure this machine is domain-joined and can reach a domain controller. Error: $_" "ERROR" "Red"
+        exit 1
+    }
 }
 
 #— 2) Build per-OU dataset
-Write-Log "Building per-OU dataset..."
+Write-Log "Building per-OU dataset..." "INFO" "Cyan"
 $byOU = Get-ByOUData `
     -DomainsToAudit $domainsToAudit `
     -ServicePattern $UserServiceAccountNamesLike `
@@ -750,11 +744,11 @@ $byOU = Get-ByOUData `
 $ouDataInput = $byOU | Select-Object -SkipLast 1
 
 #— 3) Aggregate by domain
-Write-Log "Building aggregated report by Domain..."
+Write-Log "Building aggregated report by Domain..." "INFO" "Cyan"
 $byDomain = Get-ByDomainData -OUData $ouDataInput
 
 #— 3b) Licensing data
-Write-Log "Preparing Rubrik licensing data..."
+Write-Log "Preparing Rubrik licensing data..." "INFO" "Cyan"
 $licensingData = $byDomain | Select-Object Domain, LicensedIdentities
 
 #— 4) Report headers
@@ -764,7 +758,7 @@ $licensingCols = Get-ReportHeaders -Type Licensing
 
 #— 5) Export CSV & HTML
 if ($Mode -eq 'Full') {
-    Write-Log "Exporting Full reports in CSV and HTML format..."
+    Write-Log "Exporting Full reports in CSV and HTML format..." "INFO" "Cyan"
 
     Export-CsvReport -FileName "Full_ByOU_$timestamp.csv"      -Data $byOU          -Columns $ouCols
     Export-CsvReport -FileName "Full_ByDomain_$timestamp.csv"  -Data $byDomain      -Columns $domainCols
@@ -782,7 +776,7 @@ if ($Mode -eq 'Full') {
                    -OutputPath $OutputPath
 }
 else {
-    Write-Log "Exporting Summary reports in CSV and HTML format..."
+    Write-Log "Exporting Summary reports in CSV and HTML format..." "INFO" "Cyan"
 
     Export-CsvReport -FileName "Summary_ByDomain_$timestamp.csv"  -Data $byDomain      -Columns $domainCols
     Export-CsvReport -FileName "Summary_Licensing_$timestamp.csv" -Data $licensingData  -Columns $licensingCols
@@ -794,8 +788,9 @@ else {
                    -OutputPath $OutputPath
 }
 
-Write-Log "AD reports generation completed."
+Write-Log "AD reports generation completed." "INFO" "Green"
 
-# Reset Culture settings back to original value
-[System.Threading.Thread]::CurrentThread.CurrentCulture = $OriginalCulture
-[System.Threading.Thread]::CurrentThread.CurrentUICulture = $OriginalUICulture
+} finally {
+    [System.Threading.Thread]::CurrentThread.CurrentCulture = $script:OriginalCulture
+    [System.Threading.Thread]::CurrentThread.CurrentUICulture = $script:OriginalUICulture
+}

--- a/IDENTITY/Get-EntraHumanIdentity.ps1
+++ b/IDENTITY/Get-EntraHumanIdentity.ps1
@@ -27,7 +27,7 @@
     - **Member**: 1 if the user is a member identity owned by this tenant (UserType = Member), 0 otherwise.
     - **Account Enabled**: 1 if the account is enabled in Entra ID, 0 if disabled.
     - **Account Disabled**: 1 if the account is disabled, 0 otherwise.
-    - **Active Identity**: 1 if the user has signed in within the configured inactivity period (default 180 days), 0 otherwise. Disabled accounts are never marked active.
+    - **Active Identity**: 1 if the user has signed in within the last 180 days, 0 otherwise. Disabled accounts are never marked active.
     - **Inactive Identity**: 1 if the user has not signed in within the inactivity period or has never signed in. Disabled accounts are never marked inactive (they are simply disabled).
     - **Never Logged In**: 1 if no sign-in activity has ever been recorded for this account, 0 otherwise.
     - **Service Account Pattern**: 1 if the user's UPN matches one of the patterns specified in -UserServiceAccountNamesLike, 0 otherwise.
@@ -57,8 +57,6 @@
     - **Applications**: Number of Entra ID application registrations published under this domain.
     - **Service Principals**: Number of service principals (enterprise apps) associated with this domain.
     - **Managed Identities**: Number of managed identities associated with this domain.
-    - **Valid Enterprise Apps**: Reserved (currently set to 0).
-
     ### Licensing Report
     - **Directory**: The domain name.
     - **Licensed Identities**: Number of users qualifying for Rubrik licensing. Formula: Member + Enabled + Active (signed in within inactivity period) + Not a service account pattern match.
@@ -87,7 +85,7 @@
 
     This command will:
     - Generate a detailed report for all users.
-    - Consider users inactive after 90 days of inactivity.
+    - Identify inactive users based on their last sign-in date.
     - Identify service accounts with UPNs starting with "svc-".
     - Check for application and service principal ownership.
     - Save the reports in both CSV and HTML format in the .\EntraReports directory.
@@ -99,17 +97,16 @@
 
     This command will:
     - Generate a high-level summary report by domain.
-    - Use the default 180-day inactivity period.
+    - Identify inactive users based on their last sign-in date.
     - Save the reports in both CSV and HTML format in the .\EntraReports directory.
 
 .NOTES
+    Author: Aymeric Jaouen
+
     - **Prerequisites**: This script requires PowerShell 7.0 or higher and the following Microsoft Graph modules: 'Microsoft.Graph.Users', 'Microsoft.Graph.Applications', and 'Microsoft.Graph.Identity.DirectoryManagement'. The script will attempt to install these modules if they are not found.
     - **Permissions**: The user running the script must have sufficient permissions in Entra ID to read user, application, and service principal information. The required permissions are 'User.Read.All', 'Directory.Read.All', 'Application.Read.All', and 'AuditLog.Read.All'. The script will prompt for login and consent to these permissions if not already granted.
     - **Execution Policy**: You may need to adjust the PowerShell execution policy to run this script. You can do this by running "Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope Process".
     - **Culture Settings**: The script temporarily sets the culture to 'en-US' to ensure that dates and times are parsed correctly. This change is reverted at the end of the script.
-
-.AUTOR
-Aymeric Jaouen
 
 #>
 
@@ -260,6 +257,7 @@ function Get-ReportHeaders {
                 PatternMatchedUser      = 'Service Account Pattern'
                 SyncFromAD              = 'Synch from AD'
                 CloudOnly               = 'Cloud Only'
+                LicensedIdentity        = 'Licensed Identity'
                 ADSourceDomain          = 'Source AD'
             }
 
@@ -292,11 +290,11 @@ function Get-ReportHeaders {
                 PatternMatchedUsers           = 'Service Account Pattern'
                 SyncFromADCount               = 'Synch from AD'
                 CloudOnlyCount                = 'Cloud Only'
+                LicensedIdentities            = 'Licensed Identities'
                 ADSourceDomainCounts          = 'Source AD'
                 DomainApplicationsCount       = 'Applications'
                 DomainServicePrincipalCount   = 'Service Principals'
                 DomainManagedIdentitiesCount  = 'Managed Identities'
-                ValidEnterpriseAppsCount      = 'Valid Enterprise Apps'
             }
         }
     }
@@ -362,51 +360,54 @@ function Get-ByUserData {
         [string[]] $ServicePattern = @(),
 
         [Parameter()]
-        [switch]   $CheckOwnership
+        [switch]   $CheckOwnership,
+
+        [Parameter(Mandatory)]
+        [object[]] $Applications,
+
+        [Parameter(Mandatory)]
+        [object[]] $ServicePrincipals
     )
 
     begin {
         $cutoff = (Get-Date).AddDays(-$DaysInactive)
         Write-Verbose "Inactivity cutoff date: $cutoff"
 
-        # Initialize an array to store the output, making it accessible to all blocks
-        $script:output = @()
+        $output = [System.Collections.Generic.List[object]]::new()
     }
 
     process {
-        Write-Verbose "Retrieving users..."
-        $users = Get-MgUser -All `
+        Write-Log "Retrieving users from Entra ID..." "INFO" "Cyan"
+        $users = Get-MgUser -All -PageSize 999 `
             -Property Id,UserPrincipalName,Mail,OtherMails,Identities,UserType,AccountEnabled,SignInActivity, `
                       OnPremisesSyncEnabled,OnPremisesDomainName `
             -ErrorAction Stop
+        Write-Log "Retrieved $($users.Count) users." "INFO" "Cyan"
 
-        Write-Verbose "Retrieving applications..."
-        $allApps = Get-MgApplication -All -ErrorAction Stop
-
-        Write-Verbose "Retrieving service principals..."
-        $filterSP = "servicePrincipalType eq 'Application' or servicePrincipalType eq 'ManagedIdentity'"
-        $allSPs = Get-MgServicePrincipal -All -Filter $filterSP -ErrorAction Stop
+        $allApps = $Applications
+        $allSPs  = $ServicePrincipals | Where-Object {
+            $_.ServicePrincipalType -eq 'Application' -or $_.ServicePrincipalType -eq 'ManagedIdentity'
+        }
 
         $appOwners   = @{}
         $spAppOwners = @{}
         $spMiOwners  = @{}
 
         if ($CheckOwnership) {
-            Write-Verbose "Retrieving ownership for each application (this may take a while)..."
+            Write-Log "Retrieving ownership for $($allApps.Count) applications..." "INFO" "Cyan"
             foreach ($app in $allApps) {
                 try {
                     $owners = Get-MgApplicationOwner -ApplicationId $app.Id
                     foreach ($owner in $owners) {
                         $appOwners[$owner.Id] = ($appOwners[$owner.Id] + 1)
                     }
-                }
-                catch {
-                    Write-Verbose "Could not get owners for application $($app.DisplayName). Error: $_"
-                    Write-Log "Could not get owners for application $($app.DisplayName). Error: $_" "ERROR" "RED"
+                } catch {
+                    Write-Log "Warning: could not retrieve owners for application '$($app.DisplayName)': $_" "WARNING" "Yellow"
                 }
             }
+            Write-Log "Application ownership: $($appOwners.Count) unique owner(s) found." "INFO" "Cyan"
 
-            Write-Verbose "Retrieving ownership for each service principal and managed identity (this may take a while)..."
+            Write-Log "Retrieving ownership for $($allSPs.Count) service principals..." "INFO" "Cyan"
             foreach ($sp in $allSPs) {
                 try {
                     $owners = Get-MgServicePrincipalOwner -ServicePrincipalId $sp.Id
@@ -416,12 +417,11 @@ function Get-ByUserData {
                             'ManagedIdentity' { $spMiOwners[$owner.Id]  = ($spMiOwners[$owner.Id]  + 1) }
                         }
                     }
-                }
-                catch {
-                    Write-Verbose "Could not get owners for service principal $($sp.DisplayName). Error: $_"
-                    Write-Log "Could not get owners for service principal $($sp.DisplayName). Error: $_" "ERROR" "RED"
+                } catch {
+                    Write-Log "Warning: could not retrieve owners for service principal '$($sp.DisplayName)': $_" "WARNING" "Yellow"
                 }
             }
+            Write-Log "SP ownership: $($spAppOwners.Count) app owner(s), $($spMiOwners.Count) MI owner(s) found." "INFO" "Cyan"
         }
         else {
             Write-Verbose "Skipping detailed ownership checks for applications, service principals, and managed identities."
@@ -432,6 +432,9 @@ function Get-ByUserData {
 
             $parts      = if ($u.UserPrincipalName) { $u.UserPrincipalName.Split('@') } else { @('','') }
             $user       = $parts[0]
+            if ($parts.Count -le 1) {
+                Write-Log "Warning: UPN without '@' detected: '$($u.UserPrincipalName)' (Id=$($u.Id))" "WARNING" "Yellow"
+            }
             $upnDomain  = if ($parts.Count -gt 1) { $parts[1].ToLowerInvariant() } else { '' }
             $directory  = Get-EffectiveUserDomain -User $u -UpnDomain $upnDomain
             $normalizedUserType = if ($u.UserType) { $u.UserType.Trim() } else { '' }
@@ -458,7 +461,7 @@ function Get-ByUserData {
 
             $patternMatched = $false
             foreach ($p in $ServicePattern) {
-                if ($u.UserPrincipalName -like "*$p*") {
+                if ($u.UserPrincipalName -like $p) {
                     $patternMatched = $true
                     break
                 }
@@ -476,7 +479,7 @@ function Get-ByUserData {
             $enterpriseCount = $spAppOwners[$u.Id]    ?? 0
             $miCount         = $spMiOwners[$u.Id]     ?? 0
 
-            $script:output += [PSCustomObject]@{
+            $output.Add([PSCustomObject]@{
                 Directory               = $directory
                 User                    = $user
                 GuestAccount            = [int]$isGuest
@@ -494,24 +497,24 @@ function Get-ByUserData {
                 OwnedAppsCount          = $ownedCount
                 EnterpriseAppsCount     = $enterpriseCount
                 ManagedIdentitiesCount  = $miCount
-            }
+            })
         }
     }
 
     end {
-        Write-Verbose "Built $($script:output.Count) user records. Calculating totals..."
-        Write-Log "Successfully built $($script:output.Count) user records." "INFO" "Green"
+        Write-Verbose "Built $($output.Count) user records. Calculating totals..."
+        Write-Log "Successfully built $($output.Count) user records." "INFO" "Green"
 
         # Build a grand-total row
         $totals = [ordered]@{ Directory = "TOTAL"; User = "" }
-        foreach ($col in $script:output | Get-Member -MemberType NoteProperty | Select-Object -Expand Name | Where-Object { $_ -notin @('Directory','User','ADSourceDomain') }) {
-            $totals[$col] = ($script:output | Measure-Object -Property $col -Sum).Sum
+        foreach ($col in $output | Get-Member -MemberType NoteProperty | Select-Object -Expand Name | Where-Object { $_ -notin @('Directory','User','ADSourceDomain') }) {
+            $totals[$col] = ($output | Measure-Object -Property $col -Sum).Sum
         }
         $totals['ADSourceDomain'] = 'N/A'
 
         # Add the total row to the end of the data and return it
-        $script:output += [PSCustomObject]$totals
-        return $script:output
+        $output.Add([PSCustomObject]$totals)
+        return $output
   }
 }
 
@@ -538,7 +541,7 @@ function Get-ByDomainData {
   )
 
   begin {
-    $rows = @()
+    $rows = [System.Collections.Generic.List[object]]::new()
 
     # Grab your tenant GUID and all verified domains
     $org = Get-MgOrganization -ErrorAction Stop
@@ -575,10 +578,7 @@ function Get-ByDomainData {
             -not [string]::IsNullOrEmpty($_.AppId) -and ($AppDomainMap[$_.AppId] -eq $domain)
           }).Count
 
-        # ValidEnterpriseAppsCount is set to 0 to avoid slow API calls
-        $validEA = 0
-
-        $rows += [PSCustomObject]@{
+        $rows.Add([PSCustomObject]@{
           Domain = $domain
           TotalUsers = $grpUsers.Count
           GuestUsers = ($grpUsers | Where-Object { $_.GuestAccount -eq 1 }).Count
@@ -600,8 +600,7 @@ function Get-ByDomainData {
           DomainApplicationsCount = $domainAppsCount
           DomainServicePrincipalCount = $tenantAppsCount
           DomainManagedIdentitiesCount = $tenantMIsCount
-          ValidEnterpriseAppsCount = $validEA
-        }
+        })
       }
 
     # Handle the 'other' domains
@@ -617,10 +616,7 @@ function Get-ByDomainData {
       -not [string]::IsNullOrEmpty($_.AppId) -and (-not ($verifiedDomains -contains $AppDomainMap[$_.AppId]) -or [string]::IsNullOrEmpty($AppDomainMap[$_.AppId]))
     }
 
-    # ValidEnterpriseAppsCount is set to 0 to avoid slow API calls
-    $validEA = 0
-
-    $rows += [PSCustomObject]@{
+    $rows.Add([PSCustomObject]@{
       Domain = "Service Principals from other Domains"
       TotalUsers = 0
       GuestUsers = 0
@@ -638,8 +634,7 @@ function Get-ByDomainData {
       DomainApplicationsCount = $otherApps.Count
       DomainServicePrincipalCount = ($otherSPs | Where-Object ServicePrincipalType -eq 'Application').Count
       DomainManagedIdentitiesCount = $otherMIs.Count
-      ValidEnterpriseAppsCount = $validEA
-    }
+    })
   }
 
   end {
@@ -671,30 +666,20 @@ function Export-CsvReport {
 
     )
 
-    # Construct the full path
     $fullPath = Join-Path -Path $outputPath -ChildPath $FileName
-
-    # Create a new, empty array for the calculated properties
     $calculatedProperties = @()
 
     try {
-
-        # Iterate through the columns and build the array of calculated properties
-         foreach ($name in $Columns.PSObject.Properties.Name) {
-        $header = $Columns."$name" # Get the custom header text
-
-        # Add a new calculated property to the array
-        $calculatedProperties += @{
-            Name       = $header
-            Expression = [scriptblock]::Create("`$_.`"$name`"")
+        foreach ($name in $Columns.PSObject.Properties.Name) {
+            $header = $Columns."$name"
+            $calculatedProperties += @{
+                Name       = $header
+                Expression = [scriptblock]::Create("`$_.`"$name`"")
+            }
         }
-    }
 
-        # Select the properties and export to a CSV with custom headers
-        $data | Select-Object -Property $calculatedProperties | Export-Csv -Path $fullPath -NoTypeInformation -Force
-
+        $data | Select-Object -Property $calculatedProperties | Export-Csv -Path $fullPath -NoTypeInformation -Encoding UTF8 -Force
         Write-Log "Successfully exported all objects in CSV file $fullPath" "INFO" "Green"
-
     }
     catch {
         Write-Log "Could not export to CSV file $fullPath. Error: $_" "ERROR" "RED"
@@ -766,17 +751,15 @@ function Export-HtmlReport {
             $html += "</div>"
             $html += "<div class='table-scroll'><table>"
 
-            # Add headers
             $html += '<thead><tr>'
             foreach ($header in $TableColumns.PSObject.Properties.Value) {
-                $html += "<th>$header</th>"
+                $safeHeader = [System.Net.WebUtility]::HtmlEncode($header)
+                $html += "<th>$safeHeader</th>"
             }
             $html += '</tr></thead>'
             $html += '<tbody>'
 
-            # Add data rows
             foreach ($row in $TableData) {
-                # Check if this is the total row
                 $isTotalRow = ($row.Directory -eq 'TOTAL' -or $row.Domain -eq 'TOTAL')
 
                 $rowClass = ""
@@ -786,7 +769,7 @@ function Export-HtmlReport {
                 $html += "<tr$rowClass>"
 
                 foreach ($colName in $TableColumns.PSObject.Properties.Name) {
-                    $value = $row."$colName"
+                    $value = [System.Net.WebUtility]::HtmlEncode("$($row."$colName")")
                     $html += "<td>$value</td>"
                 }
                 $html += '</tr>'
@@ -939,7 +922,7 @@ function Export-HtmlReport {
         $htmlBody += @"
         <div class="footer">
             Generated on $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')<br/>
-            Command: $($script:commandLine)
+            Command: $([System.Net.WebUtility]::HtmlEncode($script:commandLine))
         </div>
     </div>
 </body>
@@ -958,35 +941,45 @@ function Export-HtmlReport {
 # 5. MAIN
 #==================================================================================================
 
-#— 1) Récupérations globales Microsoft Graph
+try {
+
+#— 1) Global Microsoft Graph data retrieval
 # Get applications and create a lookup table for AppId -> PublisherDomain
 Write-Log "Loading global Graph data - Fetching Applications..." "INFO" "Cyan"
-$applications = Get-MgApplication -All -Property PublisherDomain,AppId,DisplayName
+$applications = Get-MgApplication -All -PageSize 999 -Property Id,PublisherDomain,AppId,DisplayName
+Write-Log "Retrieved $($applications.Count) applications." "INFO" "Cyan"
 $appDomainMap = @{}
 foreach ($app in $applications) {
     if (-not [string]::IsNullOrEmpty($app.PublisherDomain)) {
+        if ($appDomainMap.ContainsKey($app.AppId)) {
+            Write-Log "Warning: duplicate AppId '$($app.AppId)' for app '$($app.DisplayName)'" "WARNING" "Yellow"
+        }
         $appDomainMap[$app.AppId] = $app.PublisherDomain
     }
 }
 
 # Get service principals with necessary properties
 Write-Log "Loading global Graph data - Fetching Service Principals..." "INFO" "Cyan"
-$servicePrincipals = Get-MgServicePrincipal -All -Property PublisherDomain,ServicePrincipalType,AppId,accountEnabled,passwordCredentials,keyCredentials
+$servicePrincipals = Get-MgServicePrincipal -All -PageSize 999 -Property PublisherDomain,ServicePrincipalType,AppId,accountEnabled,passwordCredentials,keyCredentials
+Write-Log "Retrieved $($servicePrincipals.Count) service principals." "INFO" "Cyan"
 
 Write-Log "Loading global Graph data - Fetching Managed Identities..." "INFO" "Cyan"
 $managedIdentities = $servicePrincipals | Where-Object servicePrincipalType -eq 'ManagedIdentity'
+Write-Log "Retrieved $($managedIdentities.Count) managed identities." "INFO" "Cyan"
 
-#— 2) Construction du rapport détaillé par utilisateur
+#— 2) Build detailed per-user report
 Write-Log "Building per-user dataset..." "INFO" "Cyan"
 $byUser = Get-ByUserData `
     -DaysInactive $DaysInactive `
     -ServicePattern $UserServiceAccountNamesLike `
-    -CheckOwnership:$CheckOwnership
+    -CheckOwnership:$CheckOwnership `
+    -Applications $applications `
+    -ServicePrincipals $servicePrincipals
 
 # Filter out the last row (the 'TOTAL' row) before passing the data to Get-ByDomainData
 $domainDataInput = $byUser | Select-Object -SkipLast 1
 
-#— 3) Agrégation par domaine
+#— 3) Aggregate by domain
 Write-Log "Building aggregated report by Domain..." "INFO" "Cyan"
 $byDomain = Get-ByDomainData `
   -UserData          $domainDataInput `
@@ -999,12 +992,12 @@ $byDomain = Get-ByDomainData `
 Write-Log "Preparing Rubrik licensing data..." "INFO" "Cyan"
 $licensingData = $byDomain | Select-Object Domain, LicensedIdentities
 
-#— 4) Préparation des en-têtes de rapport
+#— 4) Prepare report headers
 $userCols      = Get-ReportHeaders -Type ByUser -CheckOwnership:$CheckOwnership
 $domainCols    = Get-ReportHeaders -Type ByDomain
 $licensingCols = Get-ReportHeaders -Type Licensing
 
-#— 6) Export CSV & HTML en fonction du mode
+#— 5) Export CSV & HTML based on mode
 if ($Mode -eq 'Full') {
     Write-Log "Exporting Full reports in CSV and HTML format..." "INFO" "Cyan"
 
@@ -1037,8 +1030,9 @@ else {
                        -OutputPath $OutputPath
 }
 
-# Reset Culture settings back to original value
-[System.Threading.Thread]::CurrentThread.CurrentCulture = $OriginalCulture
-[System.Threading.Thread]::CurrentThread.CurrentUICulture = $OriginalUICulture
-
 Write-Log "ENTRA ID reports generation completed." "INFO" "Green"
+
+} finally {
+    [System.Threading.Thread]::CurrentThread.CurrentCulture = $script:OriginalCulture
+    [System.Threading.Thread]::CurrentThread.CurrentUICulture = $script:OriginalUICulture
+}

--- a/IDENTITY/Get-EntraHumanIdentity.ps1
+++ b/IDENTITY/Get-EntraHumanIdentity.ps1
@@ -384,10 +384,11 @@ function Get-ByUserData {
             -ErrorAction Stop
         Write-Log "Retrieved $($users.Count) users." "INFO" "Cyan"
 
-        $allApps = $Applications
-        $allSPs  = $ServicePrincipals | Where-Object {
-            $_.ServicePrincipalType -eq 'Application' -or $_.ServicePrincipalType -eq 'ManagedIdentity'
-        }
+        $allApps = @($Applications | Where-Object { -not [string]::IsNullOrEmpty($_.Id) })
+        $allSPs  = @($ServicePrincipals | Where-Object {
+            -not [string]::IsNullOrEmpty($_.Id) -and
+            ($_.ServicePrincipalType -eq 'Application' -or $_.ServicePrincipalType -eq 'ManagedIdentity')
+        })
 
         $appOwners   = @{}
         $spAppOwners = @{}
@@ -960,7 +961,7 @@ foreach ($app in $applications) {
 
 # Get service principals with necessary properties
 Write-Log "Loading global Graph data - Fetching Service Principals..." "INFO" "Cyan"
-$servicePrincipals = Get-MgServicePrincipal -All -PageSize 999 -Property PublisherDomain,ServicePrincipalType,AppId,accountEnabled,passwordCredentials,keyCredentials
+$servicePrincipals = Get-MgServicePrincipal -All -PageSize 999 -Property Id,DisplayName,PublisherDomain,ServicePrincipalType,AppId,accountEnabled,passwordCredentials,keyCredentials
 Write-Log "Retrieved $($servicePrincipals.Count) service principals." "INFO" "Cyan"
 
 Write-Log "Loading global Graph data - Fetching Managed Identities..." "INFO" "Cyan"

--- a/IDENTITY/Get-EntraHumanIdentity.ps1
+++ b/IDENTITY/Get-EntraHumanIdentity.ps1
@@ -17,8 +17,51 @@
         - **Summary**: A high-level report with aggregated counts for each domain.
 
     The script generates both CSV and HTML reports that can be shared with Rubrik for licensing purposes.
-    
-    Author : Aymeric Jaouen
+
+    ## Report Columns
+
+    ### Per-User Report (ByUser)
+    - **Directory**: The domain associated with the user (resolved from mail, identities, or UPN for guests; from on-premises domain for synced users).
+    - **User**: The user's account name (the part before @ in the UPN).
+    - **Guest**: 1 if the user is an external/guest identity (UserType = Guest), 0 otherwise.
+    - **Member**: 1 if the user is a member identity owned by this tenant (UserType = Member), 0 otherwise.
+    - **Account Enabled**: 1 if the account is enabled in Entra ID, 0 if disabled.
+    - **Account Disabled**: 1 if the account is disabled, 0 otherwise.
+    - **Active Identity**: 1 if the user has signed in within the configured inactivity period (default 180 days), 0 otherwise. Disabled accounts are never marked active.
+    - **Inactive Identity**: 1 if the user has not signed in within the inactivity period or has never signed in. Disabled accounts are never marked inactive (they are simply disabled).
+    - **Never Logged In**: 1 if no sign-in activity has ever been recorded for this account, 0 otherwise.
+    - **Service Account Pattern**: 1 if the user's UPN matches one of the patterns specified in -UserServiceAccountNamesLike, 0 otherwise.
+    - **Synch from AD**: 1 if the account is synchronized from on-premises Active Directory (OnPremisesSyncEnabled = true), 0 otherwise.
+    - **Cloud Only**: 1 if the account exists only in Entra ID (not synced from AD), 0 otherwise.
+    - **Licensed Identity**: 1 if the user qualifies for Rubrik licensing (Member AND Enabled AND Active AND not a pattern-matched service account), 0 otherwise.
+    - **Source AD**: The on-premises AD domain name for synced accounts, N/A for cloud-only accounts.
+    - **App owned by User** (only with -CheckOwnership): Number of Entra ID application registrations owned by this user.
+    - **SP owned by User** (only with -CheckOwnership): Number of service principals (enterprise apps) owned by this user.
+    - **Managed Identity** (only with -CheckOwnership): Number of managed identities owned by this user.
+
+    ### Per-Domain Report (ByDomain)
+    - **Directory**: The domain name.
+    - **Total Users**: Total number of user accounts associated with this domain.
+    - **Guest Users**: Number of guest/external accounts.
+    - **Member Users**: Number of member accounts.
+    - **Account Enabled**: Number of enabled accounts.
+    - **Account Disabled**: Number of disabled accounts.
+    - **Active Identity**: Number of users who signed in within the inactivity period.
+    - **Inactive Identity**: Number of users who have not signed in within the inactivity period.
+    - **Never Logged In Users**: Number of accounts with no recorded sign-in.
+    - **Service Account Pattern**: Number of accounts matching the service account naming patterns.
+    - **Synch from AD**: Number of accounts synchronized from on-premises AD.
+    - **Cloud Only**: Number of cloud-only accounts.
+    - **Licensed Identities**: Number of users qualifying for Rubrik licensing (Member + Enabled + Active + not service account).
+    - **Source AD**: Number of distinct on-premises AD source domains for synced accounts.
+    - **Applications**: Number of Entra ID application registrations published under this domain.
+    - **Service Principals**: Number of service principals (enterprise apps) associated with this domain.
+    - **Managed Identities**: Number of managed identities associated with this domain.
+    - **Valid Enterprise Apps**: Reserved (currently set to 0).
+
+    ### Licensing Report
+    - **Directory**: The domain name.
+    - **Licensed Identities**: Number of users qualifying for Rubrik licensing. Formula: Member + Enabled + Active (signed in within inactivity period) + Not a service account pattern match.
 
 .PARAMETER UserServiceAccountNamesLike
     This is an optional parameter that allows you to identify service accounts based on their User Principal Name (UPN). You can provide a list of wildcard patterns, and any user account with a UPN matching one of these patterns will be flagged as a service account in the report.
@@ -32,20 +75,15 @@
 
     The default value is 'Full'.
 
-.PARAMETER DaysInactive
-    This parameter allows you to specify the number of days of inactivity after which a user is considered inactive. The default value is 180 days.
-
-    Example: -DaysInactive 90
-
 .PARAMETER CheckOwnership
     This is an optional switch parameter. If you include this parameter, the script will perform additional queries to determine the owners of applications and service principals. This provides more detailed information but can increase the script's execution time.
 
     Example: -CheckOwnership
 
 .EXAMPLE
-    Example 1: Perform a full audit with ownership checking and a 90-day inactivity period.
+    Example 1: Perform a full audit with ownership checking
 
-    .\Get-EntraHumanIdentity.ps1 -Mode Full -DaysInactive 90 -UserServiceAccountNamesLike "svc-*" -CheckOwnership
+    .\Get-EntraHumanIdentity.ps1 -Mode Full -UserServiceAccountNamesLike "svc-*" -CheckOwnership
 
     This command will:
     - Generate a detailed report for all users.
@@ -69,6 +107,10 @@
     - **Permissions**: The user running the script must have sufficient permissions in Entra ID to read user, application, and service principal information. The required permissions are 'User.Read.All', 'Directory.Read.All', 'Application.Read.All', and 'AuditLog.Read.All'. The script will prompt for login and consent to these permissions if not already granted.
     - **Execution Policy**: You may need to adjust the PowerShell execution policy to run this script. You can do this by running "Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope Process".
     - **Culture Settings**: The script temporarily sets the culture to 'en-US' to ensure that dates and times are parsed correctly. This change is reverted at the end of the script.
+
+.AUTOR
+Aymeric Jaouen
+
 #>
 
 param (
@@ -117,9 +159,11 @@ try {
         }
         $commandString += " -$paramName $formattedValue"
     }
+    $script:commandLine = $commandString
     Write-Log "Script started with command: $commandString" "INFO" "Magenta"
 }
 catch {
+    $script:commandLine = "N/A"
     Write-Log "Could not log the command line. Error: $_" "WARNING" "Yellow"
 }
 
@@ -195,7 +239,7 @@ Connect-EntraGraph
 function Get-ReportHeaders {
     param(
         [Parameter(Mandatory)]
-        [ValidateSet('ByUser', 'ByDomain')]
+        [ValidateSet('ByUser', 'ByDomain', 'Licensing')]
         [string] $Type,
         [Parameter()]
         [switch] $CheckOwnership
@@ -225,6 +269,13 @@ function Get-ReportHeaders {
                 $baseHeaders['ManagedIdentitiesCount']  = 'Managed Identity'
             }
             return [PSCustomObject]$baseHeaders
+        }
+
+        'Licensing' {
+            return [PSCustomObject]@{
+                Domain             = 'Directory'
+                LicensedIdentities = 'Licensed Identities'
+            }
         }
 
         'ByDomain' {
@@ -421,9 +472,9 @@ function Get-ByUserData {
                 'N/A'
             }
 
-            $ownedCount      = $appOwners[$u.Id]      -or 0
-            $enterpriseCount = $spAppOwners[$u.Id]    -or 0
-            $miCount         = $spMiOwners[$u.Id]     -or 0
+            $ownedCount      = $appOwners[$u.Id]      ?? 0
+            $enterpriseCount = $spAppOwners[$u.Id]    ?? 0
+            $miCount         = $spMiOwners[$u.Id]     ?? 0
 
             $script:output += [PSCustomObject]@{
                 Directory               = $directory
@@ -438,6 +489,7 @@ function Get-ByUserData {
                 PatternMatchedUser      = [int]$patternMatched
                 SyncFromAD              = [int]$syncFromAD
                 CloudOnly               = $cloudOnly
+                LicensedIdentity        = [int]($isMember -and $isEnabled -and $isActive -and -not $patternMatched)
                 ADSourceDomain          = $adSourceDomain
                 OwnedAppsCount          = $ownedCount
                 EnterpriseAppsCount     = $enterpriseCount
@@ -539,6 +591,7 @@ function Get-ByDomainData {
           PatternMatchedUsers = ($grpUsers | Where-Object { $_.PatternMatchedUser -eq 1 }).Count
           SyncFromADCount = ($grpUsers | Where-Object { $_.SyncFromAD -eq 1 }).Count
           CloudOnlyCount = ($grpUsers | Where-Object { $_.CloudOnly -eq 1 }).Count
+          LicensedIdentities = ($grpUsers | Where-Object { $_.LicensedIdentity -eq 1 }).Count
           ADSourceDomainCounts = @(
             $grpUsers |
             Where-Object { $_.SyncFromAD -eq 1 -and -not [string]::IsNullOrWhiteSpace($_.ADSourceDomain) -and $_.ADSourceDomain -ne 'N/A' } |
@@ -573,12 +626,14 @@ function Get-ByDomainData {
       GuestUsers = 0
       MemberUsers = 0
       AccountEnabledCount = 0
+      DisabledUsers = 0
       ActiveUsers = 0
       InactiveUsers = 0
       NeverLoggedInUsers = 0
       PatternMatchedUsers = 0
       SyncFromADCount = 0
       CloudOnlyCount = 0
+      LicensedIdentities = 0
       ADSourceDomainCounts = 0
       DomainApplicationsCount = $otherApps.Count
       DomainServicePrincipalCount = ($otherSPs | Where-Object ServicePrincipalType -eq 'Application').Count
@@ -659,6 +714,15 @@ function Export-HtmlReport {
 
         [Parameter(Mandatory)]
         [PSCustomObject] $Columns,
+
+        [Parameter()]
+        [string] $MiddleReportTitle,
+
+        [Parameter()]
+        [object[]] $MiddleReportData,
+
+        [Parameter()]
+        [PSCustomObject] $MiddleReportColumns,
 
         [Parameter()]
         [string] $SecondReportTitle,
@@ -860,6 +924,12 @@ function Export-HtmlReport {
         # Add the first table
         $htmlBody += New-HtmlTable -TableTitle $Title -TableData $Data -TableColumns $Columns
 
+        # If a middle report (licensing) is provided, add it
+        if ($MiddleReportData) {
+            $htmlBody += "<br>"
+            $htmlBody += New-HtmlTable -TableTitle $MiddleReportTitle -TableData $MiddleReportData -TableColumns $MiddleReportColumns
+        }
+
         # If a second report is provided, add it
         if ($SecondReportData) {
             $htmlBody += "<br>"
@@ -868,7 +938,8 @@ function Export-HtmlReport {
 
         $htmlBody += @"
         <div class="footer">
-            Generated on $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')
+            Generated on $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')<br/>
+            Command: $($script:commandLine)
         </div>
     </div>
 </body>
@@ -924,20 +995,29 @@ $byDomain = Get-ByDomainData `
   -ManagedIdentities $managedIdentities `
   -AppDomainMap      $appDomainMap
 
+#— 3b) Licensing: extract from domain data
+Write-Log "Preparing Rubrik licensing data..." "INFO" "Cyan"
+$licensingData = $byDomain | Select-Object Domain, LicensedIdentities
+
 #— 4) Préparation des en-têtes de rapport
-$userCols   = Get-ReportHeaders -Type ByUser -CheckOwnership:$CheckOwnership
-$domainCols = Get-ReportHeaders -Type ByDomain
+$userCols      = Get-ReportHeaders -Type ByUser -CheckOwnership:$CheckOwnership
+$domainCols    = Get-ReportHeaders -Type ByDomain
+$licensingCols = Get-ReportHeaders -Type Licensing
 
 #— 6) Export CSV & HTML en fonction du mode
 if ($Mode -eq 'Full') {
     Write-Log "Exporting Full reports in CSV and HTML format..." "INFO" "Cyan"
 
-    Export-CsvReport -FileName "Full_ByUser_$timestamp.csv"    -Data  $byUser   -Columns $userCols
-    Export-CsvReport -FileName "Full_ByDomain_$timestamp.csv"  -Data  $byDomain -Columns $domainCols
+    Export-CsvReport -FileName "Full_ByUser_$timestamp.csv"      -Data $byUser        -Columns $userCols
+    Export-CsvReport -FileName "Full_ByDomain_$timestamp.csv"    -Data $byDomain      -Columns $domainCols
+    Export-CsvReport -FileName "Full_Licensing_$timestamp.csv"   -Data $licensingData -Columns $licensingCols
     Export-HtmlReport -FileName "Full_Report_$timestamp.html" `
                    -Title 'Domain Summary' `
                    -Data  $byDomain `
                    -Columns $domainCols `
+                   -MiddleReportTitle 'Rubrik Licensing' `
+                   -MiddleReportData $licensingData `
+                   -MiddleReportColumns $licensingCols `
                    -SecondReportTitle 'User Details' `
                    -SecondReportData $byUser `
                    -SecondReportColumns $userCols `
@@ -947,9 +1027,14 @@ if ($Mode -eq 'Full') {
 else {
     Write-Log "Exporting Summary reports in CSV and HTML format..." "INFO" "Cyan"
 
-    Export-CsvReport   -FileName "Summary_ByDomain_$timestamp.csv" -Data  $byDomain -Columns $domainCols
-    Export-HtmlReport  -FileName "Summary_Report_$timestamp.html"  -Title 'EntraID Summary'    `
-                       -Data  $byDomain -Columns $domainCols
+    Export-CsvReport   -FileName "Summary_ByDomain_$timestamp.csv"    -Data $byDomain      -Columns $domainCols
+    Export-CsvReport   -FileName "Summary_Licensing_$timestamp.csv"  -Data $licensingData -Columns $licensingCols
+    Export-HtmlReport  -FileName "Summary_Report_$timestamp.html" -Title 'EntraID Summary' `
+                       -Data $byDomain -Columns $domainCols `
+                       -MiddleReportTitle 'Rubrik Licensing' `
+                       -MiddleReportData $licensingData `
+                       -MiddleReportColumns $licensingCols `
+                       -OutputPath $OutputPath
 }
 
 # Reset Culture settings back to original value

--- a/IDENTITY/README.md
+++ b/IDENTITY/README.md
@@ -48,7 +48,7 @@ This script is a Rubrik utility for counting human identities in a customer's Ac
 | Parameter                       | Description                                                                                                                         | Required | Default Value             |
 | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------------- |
 | `SpecificDomains`               | An array of fully qualified domain names to audit (e.g., `"corp.domain.local"`). If omitted, all domains in the forest are audited. | No       | All domains in the forest |
-| `UserServiceAccountNamesLike`   | An array of wildcard patterns to identify service accounts by name (e.g., `"*svc*"`, `"*_bot*"`).                                   | No       | None                      |
+| `UserServiceAccountNamesLike`   | An array of wildcard patterns to identify service accounts by name. Patterns are used as-is with `-like`, so include wildcards explicitly (e.g., `"*svc*"` for contains-match, `"svc-*"` for prefix-match). | No       | None                      |
 | `ExcludeOUs`                    | An array of OU distinguished names to exclude from the audit (exact match on the full DN).                                          | No       | None                      |
 | `Mode`                          | The reporting mode. `Full` for a detailed per-OU report or `Summary` for a domain-level summary.                                    | Yes      | `Full`                    |
 
@@ -105,7 +105,7 @@ This script is a Rubrik utility for counting human identities in a customer's En
 
 | Parameter                       | Description                                                                                                              | Required | Default Value |
 | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | -------- | ------------- |
-| `UserServiceAccountNamesLike`   | An array of patterns to identify service accounts by their UPN (e.g., `"svc-"`, `"sa-"`).                                | No       | None          |
+| `UserServiceAccountNamesLike`   | An array of wildcard patterns to identify service accounts by their UPN. Patterns are used as-is with `-like`, so include wildcards explicitly (e.g., `"*svc*"` for contains-match, `"svc-*"` for prefix-match). | No       | None          |
 | `Mode`                          | The reporting mode. `Full` for a detailed per-user report or `Summary` for an aggregated report.                         | Yes      | `Full`        |
 | `CheckOwnership`                | When present, enables the check for application and service principal ownership. This is time-consuming on large tenants. | No       | Not present   |
 
@@ -120,7 +120,7 @@ This script is a Rubrik utility for counting human identities in a customer's En
 **Example 2: Generate a summary report, identifying service accounts with "svc-" in their UPN.**
 
 ```powershell
-.\Get-EntraHumanIdentity.ps1 -Mode Summary -UserServiceAccountNamesLike "svc-"
+.\Get-EntraHumanIdentity.ps1 -Mode Summary -UserServiceAccountNamesLike "*svc*"
 ```
 
 ### Output

--- a/IDENTITY/README.md
+++ b/IDENTITY/README.md
@@ -32,9 +32,9 @@ This script is a Rubrik utility for counting human identities in a customer's Ac
     -   Accounts with the `PasswordNeverExpires` flag set.
     -   Accounts matching custom naming patterns (e.g., `*svc*`, `*_bot`).
 -   **Flexible Reporting**: Generates reports in two modes:
-    -   `UserPerOU`: A detailed breakdown of accounts per Organizational Unit (OU).
+    -   `Full`: A detailed breakdown of accounts per Organizational Unit (OU).
     -   `Summary`: A high-level summary of accounts per domain.
--   **CSV Export**: Automatically exports the audit results to a timestamped CSV file that can be shared with Rubrik.
+-   **CSV & HTML Export**: Automatically exports the audit results to timestamped CSV and HTML files that can be shared with Rubrik.
 -   **Logging**: Creates a detailed log file for each execution, capturing all actions and potential errors.
 
 ### Prerequisites
@@ -45,18 +45,19 @@ This script is a Rubrik utility for counting human identities in a customer's Ac
 
 ### Parameters
 
-| Parameter                     | Description                                                                                                                           | Required | Default Value |
-| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------| -------- | ------------- |
-| `SpecificDomains`             | An array of fully qualified domain names to audit (e.g., `"corp.domain.local"`). If omitted, all domains in the forest are audited.   | No       | (All domains in the forest) |
-| `UserServiceAccountNamesLike` | An array of wildcard patterns to identify service accounts by name (e.g., `"*svc*"`, `"*_bot*"`).                                     | No       | (None)        |
-| `Mode`                        | The reporting mode. Can be `UserPerOU` for a detailed report or `Summary` for a domain-level summary.                                 | Yes      | `UserPerOU`   |
+| Parameter                       | Description                                                                                                                         | Required | Default Value             |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------------- |
+| `SpecificDomains`               | An array of fully qualified domain names to audit (e.g., `"corp.domain.local"`). If omitted, all domains in the forest are audited. | No       | All domains in the forest |
+| `UserServiceAccountNamesLike`   | An array of wildcard patterns to identify service accounts by name (e.g., `"*svc*"`, `"*_bot*"`).                                   | No       | None                      |
+| `ExcludeOUs`                    | An array of OU distinguished names to exclude from the audit (exact match on the full DN).                                          | No       | None                      |
+| `Mode`                          | The reporting mode. `Full` for a detailed per-OU report or `Summary` for a domain-level summary.                                    | Yes      | `Full`                    |
 
 ### Usage Examples
 
 **Example 1: Audit all domains in the forest with a detailed per-OU report.**
 
 ```powershell
-.\Get-AdHumanIdentity.ps1 -Mode UserPerOU
+.\Get-AdHumanIdentity.ps1 -Mode Full
 ```
 
 **Example 2: Audit a specific domain and identify service accounts by name, with a summary report.**
@@ -67,7 +68,8 @@ This script is a Rubrik utility for counting human identities in a customer's Ac
 
 ### Output
 
--   **CSV Report**: A CSV file named `UserAudit_<Mode>_<timestamp>.csv` is created in the `ADReports` directory.
+-   **CSV Reports**: CSV files are created in the `ADReports` directory (ByOU, ByDomain, Licensing in Full mode; ByDomain, Licensing in Summary mode).
+-   **HTML Report**: An HTML report with Rubrik branding is created in the `ADReports` directory.
 -   **Log File**: A log file named `AD_Audit_<timestamp>.log` is created in the `ADReports` directory.
 
 ---
@@ -79,7 +81,7 @@ This script is a Rubrik utility for counting human identities in a customer's En
 ### Features
 
 -   **Microsoft Graph Integration**: Connects to Microsoft Graph with the necessary permissions to read identity data.
--   **User Activity Analysis**: Identifies inactive users based on a configurable number of days of inactivity to help differentiate between active and dormant human users.
+-   **User Activity Analysis**: Identifies inactive users based on 180 days of inactivity to help differentiate between active and dormant human users.
 -   **Service Account Identification**: Flags potential service accounts based on naming patterns in their User Principal Name (UPN) to exclude them from the human identity count.
 -   **Application and Service Principal Ownership**: Optionally performs a deep scan to count the number of applications and service principals owned by each user, which helps in distinguishing human from non-human accounts.
 -   **Comprehensive Reporting**: Generates reports in two modes:
@@ -101,19 +103,18 @@ This script is a Rubrik utility for counting human identities in a customer's En
 
 ### Parameters
 
-| Parameter                     | Description                                                                                                | Required | Default Value |
-| ----------------------------- | ---------------------------------------------------------------------------------------------------------- | -------- | ------------- |
-| `UserServiceAccountNamesLike` | An array of patterns to identify service accounts by their UPN (e.g., `"svc-"`, `"sa-"`).                  | No       | (None)        |
-| `Mode`                        | The reporting mode. Can be `Full` for a detailed report or `Summary` for an aggregated report.             | Yes      | `Full`        |
-| `DaysInactive`                | The number of days of inactivity to use when flagging users as inactive.                                   | No       | `180`         |
-| `CheckOwnership`              | A switch parameter that, when present, enables the time-consuming check for application and service principal ownership. | No       | (Not present) |
+| Parameter                       | Description                                                                                                              | Required | Default Value |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | -------- | ------------- |
+| `UserServiceAccountNamesLike`   | An array of patterns to identify service accounts by their UPN (e.g., `"svc-"`, `"sa-"`).                                | No       | None          |
+| `Mode`                          | The reporting mode. `Full` for a detailed per-user report or `Summary` for an aggregated report.                         | Yes      | `Full`        |
+| `CheckOwnership`                | When present, enables the check for application and service principal ownership. This is time-consuming on large tenants. | No       | Not present   |
 
 ### Usage Examples
 
-**Example 1: Generate a full report with ownership analysis, for users inactive for 90 days.**
+**Example 1: Generate a full report with ownership analysis.**
 
 ```powershell
-.\Get-EntraHumanIdentity.ps1 -Mode Full -DaysInactive 90 -CheckOwnership
+.\Get-EntraHumanIdentity.ps1 -Mode Full -CheckOwnership
 ```
 
 **Example 2: Generate a summary report, identifying service accounts with "svc-" in their UPN.**
@@ -144,3 +145,7 @@ These scripts are provided by Rubrik for licensing purposes. For support, please
 ## License
 
 This project is licensed under the MIT License. See the `LICENSE` file for details.
+
+## Author
+
+Aymeric Jaouen


### PR DESCRIPTION
## Summary

- New `IDENTITY/` directory with two PowerShell scripts for auditing human identities for Rubrik licensing:
  - `Get-AdHumanIdentity.ps1` — on-premises Active Directory (PS 5.1+, RSAT module)
  - `Get-EntraHumanIdentity.ps1` — Microsoft Entra ID via Microsoft Graph API (PS 7.0+)
- Both scripts follow the same architecture: Headers → Helpers → Detail → Summary → Exporters → Main
- Rubrik licensing calculation built-in: automatically computes licensed identities per domain
- HTML reports with Rubrik branding (Domain Summary, Rubrik Licensing, Detail tables)
- CSV exports: ByOU/ByUser, ByDomain, and Licensing
- Modes: Full (detailed) and Summary (aggregated by domain)
- AD script supports ExcludeOUs parameter for exact-match OU exclusion
- Includes bug fixes from code review: Get-OUFromDN array slice, ownership count boolean coercion, ByDomain schema consistency

## Test plan

- [ ] Run Get-AdHumanIdentity.ps1 -Mode Full — verify 3 CSVs + 1 HTML with 3 sections
- [ ] Run Get-AdHumanIdentity.ps1 -Mode Summary — verify 2 CSVs + 1 HTML with 2 sections
- [ ] Run Get-EntraHumanIdentity.ps1 -Mode Full — verify 3 CSVs + 1 HTML with 3 sections
- [ ] Run Get-EntraHumanIdentity.ps1 -Mode Summary — verify 2 CSVs + 1 HTML with 2 sections
- [ ] Verify LicensedIdentities counts match expected formula
- [ ] Verify command line appears in log file and HTML footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)