### PR TITLE
chore: add overall CODEOWNERS for mtellin and stevenctong

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,6 +3,9 @@
 # Users listed here will be automatically requested for review when a PR modifies files in their owned paths.
 # More info: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
+# Overall maintainers — any one can approve a PR
+* @mtellin @stevenctong
+
 # CLOUD folder ownership
 /CLOUD/ @bhaskard @srikar-rubrik-dev @sri-codebrik @visharma28
 


### PR DESCRIPTION
## Summary

- Adds a catch-all `*` rule to CODEOWNERS with `@mtellin` and `@stevenctong` as overall maintainers
- Preserves the existing `/CLOUD/` scoped ownership for the Cloud team

## Test plan

- [ ] Confirm GitHub surfaces both owners as required reviewers on a non-CLOUD PR
- [ ] Confirm CLOUD PRs still route to the Cloud team owners