### PR TITLE
fix: select Azure subscriptions by ID instead of display name

### DIFF
--- a/CLOUD/Get-AzureSizingInfo.ps1
+++ b/CLOUD/Get-AzureSizingInfo.ps1
@@ -278,7 +278,7 @@ param (
 )
 
 # Script version — update this with every PR that modifies this script.
-$scriptVersion = "1.0.2"
+$scriptVersion = "1.0.3"
 
 # Provider-specific anonymization configuration
 $script:tagPrefix = "Tag:"
@@ -1805,9 +1805,9 @@ foreach ($sub in $subs) {
   $subNum++
 
   try {
-    Set-AzContext -SubscriptionName $sub.Name -TenantId $context.Tenant.Id -ErrorAction Stop | Out-Null
+    Set-AzContext -SubscriptionId $sub.Id -TenantId $context.Tenant.Id -ErrorAction Stop | Out-Null
   } catch {
-    Write-Error "Error switching to subscription: $($sub.Name)"
+    Write-Error "Error switching to subscription: $($sub.Name) ($($sub.Id))"
     Write-Error "Error: $_"
     Continue
   }
@@ -1839,9 +1839,9 @@ foreach ($sub in $subs) {
   $subNum++
 
   try {
-    Set-AzContext -SubscriptionName $sub.Name -TenantId $context.Tenant.Id -ErrorAction Stop | Out-Null
+    Set-AzContext -SubscriptionId $sub.Id -TenantId $context.Tenant.Id -ErrorAction Stop | Out-Null
   } catch {
-    Write-Error "Error switching to subscription: $($sub.Name)"
+    Write-Error "Error switching to subscription: $($sub.Name) ($($sub.Id))"
     Write-Error "Error: $_"
     Continue
   }

--- a/CLOUD/README.md
+++ b/CLOUD/README.md
@@ -316,7 +316,7 @@ To run the Azure sizing script, ensure you have the following:
 - PowerShell 7 installed if running locally.
 - Required Azure PowerShell modules installed:
     ```powershell
-    Install-Module Az.Accounts,Az.Compute,Az.Storage,Az.Sql,Az.SqlVirtualMachine,Az.ResourceGraph,Az.Monitor,Az.Resources,Az.RecoveryServices,Az.CostManagement,Az.CosmosDB
+    Install-Module Az.Accounts,Az.Aks,Az.Compute,Az.Storage,Az.Sql,Az.SqlVirtualMachine,Az.ResourceGraph,Az.Monitor,Az.Resources,Az.RecoveryServices,Az.CostManagement,Az.CosmosDB
     ```
 
 ### Running the Azure Script


### PR DESCRIPTION
Fixes #134

## Problem

Both subscription loops in `Get-AzureSizingInfo.ps1` switch context by display name:

```powershell
Set-AzContext -SubscriptionName $sub.Name -TenantId $context.Tenant.Id -ErrorAction Stop | Out-Null
```

Azure subscription display names are not unique. On an ambiguous name `Set-AzContext` does not throw — it binds to the first match. The loop then re-scans that one subscription once per duplicate and never visits the others, and the script still reports success.

This is easy to hit without doing anything unusual: Visual Studio / MSDN subscriptions are provisioned with default display names like `Visual Studio Enterprise Subscription`, so a tenant with a number of them can have a large share of its subscriptions collapsed onto a handful of names.

Passing `-SubscriptionIds` does not avoid it — that parameter set only builds the list; the loop still switches by name.

## Fix

Select by ID at both call sites. `Get-AzSubscription` already returns `.Id`, so there is no extra lookup:

```powershell
Set-AzContext -SubscriptionId $sub.Id -TenantId $context.Tenant.Id -ErrorAction Stop | Out-Null
```

The `catch` block now includes the subscription ID as well, since the name alone is ambiguous exactly when this path fails.

This is the same class of fix as #124, which resolves management group display names to IDs — this one is a layer down, in the subscription loop.

## Also included

`Az.Aks` added to the README's `Install-Module` list. The script calls `Get-AzAksCluster` and `Get-AzAksNodePool`, and `CLOUD/CLAUDE.md` already lists `Az.Aks` under required Azure modules, but `README.md` omitted it. On a clean install following the README, AKS collection fails with:

```
The term 'Get-AzAksCluster' is not recognized as a name of a cmdlet, function, script file, or executable program.
```

## Verification

Two enabled subscriptions sharing one display name — **A** containing only a `networkWatchers` resource (nothing the script collects), **B** containing a storage account. Both passed by ID:

```powershell
./Get-AzureSizingInfo.ps1 -SubscriptionIds "<A>,<B>"
```

| | `master` (v1.0.2) | this branch (v1.0.3) |
|---|---|---|
| Console | `Successfully collected data from 2 out of 2 found subscriptions` | `Successfully collected data from 2 out of 2 found subscriptions` |
| `azure_storage_account_info-*.csv` | **empty, 0 bytes** | contains B's storage account, 899 bytes |

Both report the same success line; only the fixed version actually visits B.

The mis-binding is deterministic rather than random — repeated `Set-AzContext -SubscriptionName <duplicated name>` calls return the same subscription ID every time, so the same subscriptions are dropped on every run.

Additionally regression-tested with a full `-AllSubscriptions` run against a tenant of several hundred subscriptions (a majority of them sharing duplicated display names): completed with data collected from every subscription and no context-switch errors.

## Notes

- `$scriptVersion` bumped `1.0.2` → `1.0.3` per the note in the script header.
- Line 2660 still uses `-SubscriptionName` when restoring the caller's original context at the end of the run. That is the same latent issue but is not part of the reported bug, so I left it out to keep this diff minimal — happy to include it if you'd prefer.
