### PR TITLE
fix: add missing eks:DescribeNodegroup and sync README prerequisites with template

### DIFF
--- a/CLOUD/Get-AWSSizingInfo-Permissions.cft
+++ b/CLOUD/Get-AWSSizingInfo-Permissions.cft
@@ -57,6 +57,7 @@ Resources:
                   - 'ec2:DescribeVolumes'
                   - 'ec2:DescribeVpcs'
                   - 'eks:DescribeCluster'
+                  - 'eks:DescribeNodegroup'
                   - 'eks:ListClusters'
                   - 'eks:ListNodegroups'
                   - 'elasticloadbalancing:DescribeLoadBalancers'

--- a/CLOUD/README.md
+++ b/CLOUD/README.md
@@ -53,25 +53,34 @@ To run the AWS sizing script, ensure you have the following:
                   "Sid": "VisualEditor0",
                   "Effect": "Allow",
                   "Action": [
-                      "backup:ListBackupPlans",
-                      "backup:ListBackupSelections",
                       "backup:GetBackupPlan",
                       "backup:GetBackupSelection",
+                      "backup:ListBackupPlans",
+                      "backup:ListBackupSelections",
+                      "backup:ListBackupVaults",
+                      "backup:ListRecoveryPointsByBackupVault",
                       "ce:GetCostAndUsage",
+                      "ce:GetDimensionValues",
                       "cloudwatch:GetMetricStatistics",
                       "cloudwatch:ListMetrics",
-                      "dynamodb:ListTables",
+                      "dynamodb:DescribeContinuousBackups",
                       "dynamodb:DescribeTable",
+                      "dynamodb:ListBackups",
+                      "dynamodb:ListTables",
+                      "ec2:DescribeImages",
                       "ec2:DescribeInstances",
                       "ec2:DescribeRegions",
+                      "ec2:DescribeSnapshots",
                       "ec2:DescribeVolumes",
                       "ec2:DescribeVpcs",
                       "eks:DescribeCluster",
+                      "eks:DescribeNodegroup",
                       "eks:ListClusters",
                       "eks:ListNodegroups",
                       "elasticloadbalancing:DescribeLoadBalancers",
                       "elasticloadbalancing:DescribeTags",
                       "elasticfilesystem:DescribeFileSystems",
+                      "fsx:DescribeBackups",
                       "fsx:DescribeFileSystems",
                       "fsx:DescribeVolumes",
                       "iam:ListAccountAliases",
@@ -82,8 +91,12 @@ To run the AWS sizing script, ensure you have the following:
                       "kms:ListAliases",
                       "kms:ListKeys",
                       "organizations:ListAccounts",
+                      "rds:DescribeDBClusterSnapshots",
                       "rds:DescribeDBClusters",
                       "rds:DescribeDBInstances",
+                      "rds:DescribeDBSnapshots",
+                      "redshift:DescribeClusters",
+                      "redshift:DescribeClusterSnapshots",
                       "route53:ListHostedZones",
                       "s3:GetBucketLocation",
                       "s3:ListAllMyBuckets",
@@ -210,7 +223,7 @@ To run the script from a local laptop or server do the following:
 1. Verify that PowerShell v7.4.5 or higher is installed.
 1. Install the AWS modules for PowerShell with the following command:
     ```powershell
-    Install-Module AWS.Tools.Common,AWS.Tools.EC2,AWS.Tools.S3,AWS.Tools.RDS,AWS.Tools.SecurityToken,AWS.Tools.Organizations,AWS.Tools.IdentityManagement,AWS.Tools.CloudWatch,AWS.Tools.ElasticFileSystem,AWS.Tools.ElasticLoadBalancing,AWS.Tools.ElasticLoadBalancingV2,AWS.Tools.SSO,AWS.Tools.SSOOIDC,AWS.Tools.FSX,AWS.Tools.Backup,AWS.Tools.CostExplorer,AWS.Tools.DynamoDBv2,AWS.Tools.Route53,AWS.Tools.SQS,AWS.Tools.SecretsManager,AWS.Tools.KeyManagementService,AWS.Tools.EKS,AWS.Tools.Redshift
+    Install-Module AWS.Tools.Common,AWS.Tools.EC2,AWS.Tools.S3,AWS.Tools.S3Control,AWS.Tools.S3Tables,AWS.Tools.RDS,AWS.Tools.SecurityToken,AWS.Tools.Organizations,AWS.Tools.IdentityManagement,AWS.Tools.CloudWatch,AWS.Tools.ElasticFileSystem,AWS.Tools.ElasticLoadBalancing,AWS.Tools.ElasticLoadBalancingV2,AWS.Tools.SSO,AWS.Tools.SSOOIDC,AWS.Tools.FSX,AWS.Tools.Backup,AWS.Tools.CostExplorer,AWS.Tools.DynamoDBv2,AWS.Tools.Route53,AWS.Tools.SQS,AWS.Tools.SecretsManager,AWS.Tools.KeyManagementService,AWS.Tools.EKS,AWS.Tools.Redshift
 
     ```
 1. Ensure AWS credentials are set up by using the `Set-AWSCredential` command. For example:


### PR DESCRIPTION
Three prerequisite gaps found while setting up the AWS sizing script. All three cause silent or confusing failures for someone following the documented setup.

## 1. `eks:DescribeNodegroup` missing from the CloudFormation template

`Get-AWSSizingInfo.ps1` calls `Get-EKSNodegroup` when enumerating node groups:

https://github.com/rubrikinc/rubrik-sizing-scripts/blob/master/CLOUD/Get-AWSSizingInfo.ps1#L1560

The template grants `eks:DescribeCluster`, `eks:ListClusters` and `eks:ListNodegroups`, but not `eks:DescribeNodegroup`. `ListNodegroups` only returns names, so node group detail collection fails with AccessDenied on a role built from this template, and `aws_eks_nodegroups_info-*.csv` comes back short.

## 2. README IAM policy had drifted from the template

The inline JSON policy in the README was missing 12 actions the template already grants:

```
backup:ListBackupVaults                 ec2:DescribeImages
backup:ListRecoveryPointsByBackupVault  ec2:DescribeSnapshots
ce:GetDimensionValues                   fsx:DescribeBackups
dynamodb:DescribeContinuousBackups      rds:DescribeDBClusterSnapshots
dynamodb:ListBackups                    rds:DescribeDBSnapshots
redshift:DescribeClusters               redshift:DescribeClusterSnapshots
```

These back the backup-capacity and native-snapshot collectors (AWS Backup recovery points, EBS/AMI, RDS/Aurora snapshots, FSx backups, DynamoDB backups + PITR, Redshift). Anyone who builds a policy from the README rather than deploying the template loses that data — and because the collectors degrade rather than fail hard, the run still completes and looks fine.

To keep these from drifting again, the README policy is now generated from the template, so the two action sets are identical. **This reorders a few pre-existing entries** into the template's ordering — no actions were removed. Happy to redo it preserving the original order if you'd rather keep the diff minimal.

## 3. `AWS.Tools.S3Control` and `AWS.Tools.S3Tables` missing from the README

The script calls `Get-S3CStorageLensConfiguration` / `Get-S3CStorageLensConfigurationList` (S3Control) and `Get-S3TTableBucketList` / `Get-S3TTableList` / `Get-S3TTable` / `Get-S3TResourceTag` (S3Tables), but neither module is in the README's `Install-Module` line.

`CLOUD/CLAUDE.md` already lists both under required AWS modules — this just brings the README in line with it.

## Verification

- CloudFormation template parses; policy contains 57 actions including `eks:DescribeNodegroup`.
- README JSON policy block parses and its action set is now byte-identical to the template's.
- I could not run `aws cloudformation validate-template` or deploy the role, so the `eks:DescribeNodegroup` requirement is derived from the cmdlet-to-action mapping for `Get-EKSNodegroup` rather than observed against a live role. The other two items were hit directly during setup.

## Unrelated question

`sts:AssumeRole` on `Resource: '*'` inside the cross-account role looks like it may not be needed — that permission belongs on the calling principal, not on the role being assumed. I have not touched it, since it may be load-bearing for a chained-assume flow I can't see from here. Worth a look if it is vestigial.
